### PR TITLE
Document no persistence in v1.1

### DIFF
--- a/src/01-Architecture-Principles.md
+++ b/src/01-Architecture-Principles.md
@@ -57,6 +57,8 @@ Zustand + immer for tiny, predictable slices.
 - metricsSlice → immutable map of ParsedSnapshots.
 - uiSlice → pointers only (snapshot-id, metricName, seriesKey).
 - Selectors in hooks ➔ no component re-render storms.
+### 4.1 Persistence in v1.1
+No slices are persisted to storage in this release; the Zustand store resets entirely on page reload.
 
 ## 5. Event Bus vs Callbacks
 | Use case | Mechanism |


### PR DESCRIPTION
## Summary
- clarify that there is no persisted state in v1.1

## Testing
- `npm test` *(fails: react-scripts not found)*