### PR TITLE
Update Architecture Principles

### DIFF
--- a/src/01-Architecture-Principles.md
+++ b/src/01-Architecture-Principles.md
@@ -24,6 +24,7 @@
 | 7       | **Services (event bus)**  | `src/services` | Contracts                          | UI                                      |
 
 ESLint "no-restricted-paths" enforces these arrows.
+`logic/processing/*` modules may import from `logic/workers/utils/*` when those utilities are small, synchronous, and pure.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that processing modules may import small synchronous helpers from `logic/workers/utils`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*