### PR TITLE
docs: add testing overview

### DIFF
--- a/src/01-Architecture-Principles.md
+++ b/src/01-Architecture-Principles.md
@@ -87,6 +87,8 @@ Fail a unit-perf test if budgets regress.
 | UI Atoms | Storybook screenshot | per variant |
 | Layout (E2E) | Playwright | load snapshot → open Inspector |
 
+See [tests/README.md](../tests/README.md) for test helpers and snapshot guidelines.
+
 ## 8. Accessibility & i18n
 - Colour tokens meet WCAG AA on dark theme.
 - All interactive elements get aria-label.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,19 @@
+# Test Utilities and Conventions
+
+This repo keeps test helpers separate from production modules.
+
+## busMock – event bus interactions
+
+`busMock` is a tiny mitt-based mock used in unit tests. Import it from
+`tests/busMock` and use `.emit()`/`.on()` just like the real event bus. Each
+call is recorded so expectations stay simple.
+
+## Zustand store helpers
+
+`renderWithStore` wraps React Testing Library rendering with a fresh Zustand
+store. State resets between tests so slices stay isolated.
+
+## Storybook snapshots for atoms
+
+UI atoms rely on Storybook for visual regression checks. Stories generate
+screenshots per variant and Jest compares them against committed snapshots.


### PR DESCRIPTION
## Summary
- document test helpers in tests/README
- reference tests README from Architecture Principles

## Testing
- `npm test --silent` *(fails: react-scripts not found)*