### PR TITLE
Add README with test and build info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# OTEL Metrics
+
+This repository documents the architecture and supporting materials for a React-based tool that visualizes OpenTelemetry metrics.
+
+## Running Tests
+
+Execute the test suite using npm:
+
+```bash
+npm test
+```
+
+## Building for Production
+
+Generate an optimized build with React Scripts:
+
+```bash
+npm run build
+```
+
+The compiled assets are output to the `build` directory by default.


### PR DESCRIPTION
## Summary
- add README for OTEL Metrics project
- include sections on Running Tests and Building for Production

## Testing
- `git status --short`