### PR TITLE
Add global CSS variables and base styles

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -1,26 +1,44 @@
+/* ----------------------------------------
+   Global Styles
+   ------------------------------------- */
+
 :root {
-  --primary-color: #0066CC;
-  --secondary-color: #4D9EFC;
-  --background-color: #F5F7FF;
-  --text-color: #333;
-  --gaugeDefaultColor: var(--primary-color);
-  --histogramBarColor: var(--secondary-color);
-  --histogramHighlightColor: var(--primary-color);
+  /* Typography */
+  --systemFont: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+
+  /* Base colors */
+  --surfaceBg: #1e1e1e;
+  --textPrimary: #e0e0e0;
+
+  /* Visualization colors */
+  --gaugeDefaultColor: #0066CC;
+  --histogramBarColor: #4D9EFC;
+  --histogramHighlightColor: #0066CC;
   --referenceLineColor: red;
   --axisLabelColor: #777;
 }
 
-body {
-  margin: 0;
-  padding: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-  background-color: var(--background-color);
-  color: var(--text-color);
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-.app-container {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem;
+body {
+  margin: 0;
+  font-family: var(--systemFont);
+  background-color: var(--surfaceBg);
+  color: var(--textPrimary);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin: 0;
+  font-weight: inherit;
 }


### PR DESCRIPTION
## Summary
- add minimal CSS reset rules
- define design tokens for font and background
- clean up body defaults

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test:unit` *(fails: vitest not found)*