### PR TITLE
Fix CopyButton prop usage

### DIFF
--- a/src/ui/organisms/ExemplarsZone.tsx
+++ b/src/ui/organisms/ExemplarsZone.tsx
@@ -121,8 +121,8 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
               <div className={styles.traceId}>
                 Trace ID: {selectedExemplar.traceId.substring(0, 10)}...
                 <CopyButton
-                  value={selectedExemplar.traceId}
-                  label="Copy trace ID"
+                  copyValue={selectedExemplar.traceId}
+                  ariaLabel="Copy trace ID"
                 />
               </div>
 
@@ -130,8 +130,8 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
                 <div className={styles.spanId}>
                   Span ID: {selectedExemplar.spanId}
                   <CopyButton
-                    value={selectedExemplar.spanId}
-                    label="Copy span ID"
+                    copyValue={selectedExemplar.spanId}
+                    ariaLabel="Copy span ID"
                   />
                 </div>
               )}

--- a/src/ui/organisms/RawJsonZone.tsx
+++ b/src/ui/organisms/RawJsonZone.tsx
@@ -104,8 +104,10 @@ export const RawJsonZone: React.FC<RawJsonZoneProps> = ({
   const displayJson = showFullContext ? fullJson : pointJson;
 
   const handleCopy = useCallback(() => {
-    void navigator.clipboard.writeText(displayJson);
+    return displayJson;
   }, [displayJson]);
+
+  const getCopyValue = useCallback(() => handleCopy(), [handleCopy]);
 
   if (isCollapsed) {
     return (
@@ -138,7 +140,7 @@ export const RawJsonZone: React.FC<RawJsonZoneProps> = ({
           >
             ▲
           </button>
-          <CopyButton onCopy={handleCopy} label="Copy JSON" />
+          <CopyButton copyValue={getCopyValue()} ariaLabel="Copy JSON" />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- update `ExemplarsZone` to use `copyValue` & `ariaLabel`
- update `RawJsonZone` to use `copyValue` via wrapper
- confirm `AttributeRow` already uses new props

## Testing
- `npm run test:unit` *(fails: vitest not found)*