### PR TITLE
Add InstrumentBadge component

### DIFF
--- a/src/ui/atoms/InstrumentBadge.module.css
+++ b/src/ui/atoms/InstrumentBadge.module.css
@@ -1,0 +1,22 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--cardBg);
+  color: var(--textPrimary);
+  border-radius: 4px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+
+.small {
+  width: 20px;
+  height: 20px;
+  font-size: 10px;
+}
+
+.large {
+  width: 28px;
+  height: 28px;
+  font-size: 12px;
+}

--- a/src/ui/atoms/InstrumentBadge.tsx
+++ b/src/ui/atoms/InstrumentBadge.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './InstrumentBadge.module.css';
+import type { MetricDefinition } from '@/contracts/types';
+
+export interface InstrumentBadgeProps {
+  type: MetricDefinition['instrumentType'];
+  size?: 'small' | 'large';
+  className?: string;
+}
+
+export const InstrumentBadge: React.FC<InstrumentBadgeProps> = ({
+  type,
+  size = 'large',
+  className,
+}) => {
+  const sizeClass = size === 'small' ? styles.small : styles.large;
+  return (
+    <span className={clsx(styles.badge, sizeClass, className)}>{type}</span>
+  );
+};

--- a/tests/InstrumentBadge.test.tsx
+++ b/tests/InstrumentBadge.test.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { InstrumentBadge } from '../src/ui/atoms/InstrumentBadge';
+
+describe('InstrumentBadge', () => {
+  it('renders the provided type', () => {
+    render(<InstrumentBadge type="Histogram" />);
+    expect(screen.getByText('Histogram')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add InstrumentBadge atom with CSS module
- create unit test for InstrumentBadge

## Testing
- `npm run test:unit` *(fails: vitest not found)*