### PR TITLE
Add shared Either type

### DIFF
--- a/src/contracts/either.ts
+++ b/src/contracts/either.ts
@@ -1,0 +1,3 @@
+export type Either<L, R> =
+  | { type: 'left'; value: L }
+  | { type: 'right'; value: R };

--- a/src/data/fileValidator.ts
+++ b/src/data/fileValidator.ts
@@ -6,6 +6,8 @@
 /**
  * Describes why validation failed.
  */
+import type { Either } from '@/contracts/either';
+
 export interface ValidationError {
   /** Error classification */
   code: 'INVALID_EXTENSION' | 'FILE_TOO_LARGE';
@@ -26,9 +28,6 @@ export interface ValidFile {
 /**
  * Discriminated union returned by {@link validateFile}.
  */
-export type Either<L, R> =
-  | { type: 'left'; value: L }
-  | { type: 'right'; value: R };
 
 const ALLOWED_EXTENSIONS = new Set(['json', 'gz', 'otel']);
 

--- a/src/logic/workers/utils/jsonSafeParse.ts
+++ b/src/logic/workers/utils/jsonSafeParse.ts
@@ -17,9 +17,7 @@
  * - Invalid `'foo{'` → `type` is `left` with message containing `"Unexpected token"`.
  * - Parsing a 10 MB string completes within ~20 ms on a 3 GHz worker.
  */
-export type Either<L, R> =
-  | { type: 'left'; value: L }
-  | { type: 'right'; value: R };
+import type { Either } from '@/contracts/either';
 
 /**
  * Safely parse a JSON string without throwing.


### PR DESCRIPTION
## Summary
- add `Either` type contract
- refactor `jsonSafeParse` and `fileValidator` to use new type

## Testing
- `npm run test:unit` *(fails: vitest not found)*