### PR TITLE
Fix inspector hook filter and params

### DIFF
--- a/src/hooks/useInspectorProps.ts
+++ b/src/hooks/useInspectorProps.ts
@@ -34,7 +34,7 @@ export function useInspectorProps(simulateDropKey?: string | null): InspectorPro
     inspectedPointId,
     isInspectorOpen,
     closeInspector,
-    addFilter,
+    setDashboardFilter,
   } = useUiSlice(state => ({
     activeSnapshotId : state.activeSnapshotId,
     inspectedMetricName: state.inspectedMetricName,
@@ -42,7 +42,7 @@ export function useInspectorProps(simulateDropKey?: string | null): InspectorPro
     inspectedPointId   : state.inspectedPointId,
     isInspectorOpen    : state.isInspectorOpen,
     closeInspector     : state.closeInspector,
-    addFilter          : state.addFilter,
+    setDashboardFilter : state.setDashboardFilter,
   }));
 
   const snapshot = useSnapshot(activeSnapshotId);
@@ -83,7 +83,7 @@ export function useInspectorProps(simulateDropKey?: string | null): InspectorPro
       },
       exemplars: point.exemplars,
       onClose: closeInspector,
-      onAddGlobalFilter: addFilter,
+      onAddGlobalFilter: setDashboardFilter,
       metricLatestNValues: undefined,
     };
 
@@ -96,6 +96,6 @@ export function useInspectorProps(simulateDropKey?: string | null): InspectorPro
     inspectedPointId,
     simulateDropKey,
     closeInspector,
-    addFilter,
+    setDashboardFilter,
   ]);
 }

--- a/src/ui/organisms/MetricInstanceWidget.tsx
+++ b/src/ui/organisms/MetricInstanceWidget.tsx
@@ -8,7 +8,7 @@ import { DataPointInspectorDrawer } from '@/ui/organisms/DataPointInspectorDrawe
  * {@link DataPointInspectorDrawer}.
  *
  * The widget obtains inspector properties using {@link useInspectorProps}
- * based on the provided snapshot and metric identifiers. It keeps track of
+ * which reads the current inspection context from global UI state. It keeps track of
  * attribute drop simulation via {@link useDropSimulation} and forwards toggle
  * events from the drawer back to the hook.
  *
@@ -37,7 +37,9 @@ export const MetricInstanceWidget: React.FC<MetricInstanceWidgetProps> = ({
   metricName,
 }) => {
   const [droppedKey, toggleDrop] = useDropSimulation();
-  const inspectorProps = useInspectorProps(snapshotId, metricName, droppedKey);
+  // Inspector props derive snapshot/metric context from uiSlice,
+  // only the optional drop simulation key is provided here.
+  const inspectorProps = useInspectorProps(droppedKey);
 
   const handleSimulateDrop = useCallback(
     (key: string, drop: boolean) => {

--- a/tests/useInspectorProps.test.tsx
+++ b/tests/useInspectorProps.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useInspectorProps } from '../src/hooks/useInspectorProps';
+import useUiSlice from '../src/state/uiSlice';
+import { useMetricsSlice } from '../src/state/metricsSlice';
+import type { ParsedSnapshot } from '../src/contracts/types';
+
+/** Minimal snapshot with one metric and point */
+const snapshot: ParsedSnapshot = {
+  id: 's1',
+  fileName: 'f.json',
+  ingestionTimestamp: 0,
+  resources: [
+    {
+      resourceAttributes: {},
+      scopes: [
+        {
+          metrics: [
+            {
+              definition: { name: 'm1', instrumentType: 'Gauge' },
+              seriesData: new Map([
+                [
+                  'm1|',
+                  {
+                    seriesKey: 'm1|',
+                    resourceAttributes: {},
+                    metricAttributes: {},
+                    points: [
+                      {
+                        timestampUnixNano: 1,
+                        value: 1,
+                        attributes: {},
+                      },
+                    ],
+                  },
+                ],
+              ]),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('useInspectorProps', () => {
+  beforeEach(() => {
+    useUiSlice.getState().resetUi();
+    useMetricsSlice.getState().clearSnapshots();
+    useMetricsSlice.getState().addSnapshot(snapshot);
+    const ui = useUiSlice.getState();
+    ui.setActiveSnapshot('s1');
+    ui.inspectMetric('m1');
+    ui.inspectSeriesAndPoint('m1|', 1);
+    ui.openInspector();
+  });
+
+  it('provides setDashboardFilter as onAddGlobalFilter', () => {
+    const { result } = renderHook(() => useInspectorProps());
+    const ui = useUiSlice.getState();
+    expect(result.current).not.toBeNull();
+    expect(result.current!.onAddGlobalFilter).toBe(ui.setDashboardFilter);
+  });
+});


### PR DESCRIPTION
## Summary
- use global ui context in MetricInstanceWidget
- wire inspector hook to `setDashboardFilter`
- add regression test for `useInspectorProps`

## Testing
- `npm run test:unit` *(fails: vitest not found)*
- `npm run lint` *(fails: missing ESLint config)*