### PR TITLE
Add minimal lint and TypeScript configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ pnpm test:unit  # Jest/Vitest
 pnpm lint
 ```
 
+After installing dependencies the project can be verified locally:
+
+```bash
+pnpm lint  # runs ESLint using eslint.config.js
+pnpm dev   # starts the Vite dev server
+```
+
+Ensure `eslint.config.js` and `tsconfig.json` exist in the repository root
+before running these commands.
+
 ## Documentation
 
 The Markdown specs inside `src/` are automatically published to

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,14 @@
+export default [
+  {
+    files: ["**/*.{js,jsx,ts,tsx,md}"],
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    rules: {
+      semi: ["error", "always"],
+    },
+  },
+];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "strict": true,
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src", "tests", "vite.config.js"]
+}


### PR DESCRIPTION
## Summary
- add `eslint.config.js` with very basic rule
- add `tsconfig.json`
- mention running `pnpm lint` and `pnpm dev` in README

## Testing
- `pnpm lint` *(fails: unable to parse TypeScript)*
- `pnpm dev` *(fails: vite not found)*