### PR TITLE
Add contracts README and changelog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ The project has strict performance budgets:
 
 1. `src/00-Overview.md` - Project overview
 2. `src/01-Architecture-Principles.md` - Contracts and boundaries
-3. `src/contracts/03-Data-Contracts.md` - TypeScript interfaces
+3. `src/contracts/README.md` - TypeScript interfaces summary
 
 Backend focus path:
 - `src/data/*.md` → `src/logic/workers/*.md` → `src/logic/processing/*.md`

--- a/src/00-Overview.md
+++ b/src/00-Overview.md
@@ -61,7 +61,7 @@ Only one round-trip to a Web Worker per file; everything else stays on-thread.
 
 ## 5. Reading order for newcomers
 - 01-Architecture-Principles.md – contract & boundaries
-- 03-Data-Contracts.md – every shared TypeScript interface
+- contracts/README.md – summary of shared TypeScript interfaces
 
 Pick a path:
 - Backend-ish? Read data/*.md → workers/*.md → processing/*.md.

--- a/src/contracts/CHANGELOG.md
+++ b/src/contracts/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Contracts Changelog
+
+All notable changes to the TypeScript contracts are documented here.
+This file follows the same Semantic Versioning rules as the workspace root.
+
+## [Unreleased]
+- Upcoming changes will be listed here.

--- a/src/contracts/README.md
+++ b/src/contracts/README.md
@@ -1,0 +1,19 @@
+# Contracts Directory
+
+This folder hosts the TypeScript interfaces used across the project.
+
+## `types.ts` vs `rawOtlpTypes.ts`
+- **types.ts** contains the canonical data structures consumed by all nano-modules. These "parsed" types are stable and used throughout the UI, state, and processing layers.
+- **rawOtlpTypes.ts** mirrors the JSON schema produced by `otelcol` when it serializes OTLP protobufs. It is used only inside parser/mapper workers so that this verbose representation does not pollute the rest of the app.
+
+## Versioning policy
+- The workspace follows Semantic Versioning. Any breaking change to `types.ts` or `rawOtlpTypes.ts` must be documented in `CHANGELOG.md` with a `BREAKING:` note and may trigger a major version bump.
+- If a migration is required, provide automated codemods or detailed steps in the changelog.
+
+## Historic conventions (from the removed `03-Data-Contracts.md`)
+- Timestamps use Unix nanoseconds (`TimestampUnixNano`).
+- `AttrValue` is limited to primitive types (`string | number | boolean`).
+- Field names are camelCase to mirror the OTLP JSON transformation.
+- Optional fields never use `null`; omit the property instead.
+
+These rules continue to apply to all contract updates.


### PR DESCRIPTION
## Summary
- add docs about TypeScript contracts
- update references to old data contracts doc

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm test:unit` *(fails: vitest not found)*
- `pnpm test:perf` *(fails: perf-budget.js not found)*
- `pnpm build` *(fails: vite not found)*