### PR TITLE
Add tsconfig and integrate with Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "playwright": "^1.37.0",
     "typescript": "^5.1.6",
     "vite": "^6.3.5",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "vite-tsconfig-paths": "^4.2.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@tsconfig/vite/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  },
+  "include": ["src", "tests"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
+  plugins: [react(), tsconfigPaths()],
 });


### PR DESCRIPTION
## Summary
- setup `tsconfig.json` at project root extending Vite defaults
- use `vite-tsconfig-paths` plugin and drop manual alias
- add plugin as a dev dependency

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run test:unit` *(fails: vitest not found)*