### PR TITLE
Add InstrumentBadge component

### DIFF
--- a/src/ui/atoms/InstrumentBadge.module.css
+++ b/src/ui/atoms/InstrumentBadge.module.css
@@ -1,0 +1,16 @@
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: var(--primary-color);
+  color: #fff;
+}
+.small {
+  width: 20px;
+  height: 20px;
+}
+.large {
+  width: 28px;
+  height: 28px;
+}

--- a/src/ui/atoms/InstrumentBadge.tsx
+++ b/src/ui/atoms/InstrumentBadge.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import clsx from 'clsx';
+import { Gauge, Sigma, BarChart2, List, HelpCircle } from 'lucide-react';
+import type { MetricDefinition } from '@/contracts/types';
+import styles from './InstrumentBadge.module.css';
+
+export interface InstrumentBadgeProps {
+  type: MetricDefinition['instrumentType'];
+  size?: 'small' | 'large';
+  className?: string;
+}
+
+const icons: Record<MetricDefinition['instrumentType'], React.ElementType> = {
+  Gauge,
+  Sum: Sigma,
+  Histogram: BarChart2,
+  Summary: List,
+  Unknown: HelpCircle,
+};
+
+export const InstrumentBadge: React.FC<InstrumentBadgeProps> = ({
+  type,
+  size = 'large',
+  className,
+}) => {
+  const Icon = icons[type] ?? HelpCircle;
+  const pixel = size === 'small' ? 16 : 24;
+
+  return (
+    <span
+      role="img"
+      aria-label={`${type} instrument`}
+      className={clsx(styles.badge, styles[size], className)}
+    >
+      <Icon size={pixel} strokeWidth={1.8} />
+    </span>
+  );
+};

--- a/tests/InstrumentBadge.test.tsx
+++ b/tests/InstrumentBadge.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { InstrumentBadge } from '../src/ui/atoms/InstrumentBadge';
+import type { MetricDefinition } from '../src/contracts/types';
+
+const types: MetricDefinition['instrumentType'][] = [
+  'Gauge',
+  'Sum',
+  'Histogram',
+  'Summary',
+  'Unknown'
+];
+
+describe('InstrumentBadge', () => {
+  types.forEach((t) => {
+    it(`renders ${t} instrument`, () => {
+      render(<InstrumentBadge type={t} />);
+      expect(screen.getByLabelText(new RegExp(t, 'i'))).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add InstrumentBadge atom and styles
- render badge in tests for all instrument types

## Testing
- `npx vitest run` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH 172.25.0.3:8080)*