### PR TITLE
Align useInspectorProps with global state

### DIFF
--- a/src/hooks/useInspectorProps.ts
+++ b/src/hooks/useInspectorProps.ts
@@ -3,8 +3,9 @@
  *
  * UI state from {@link useUiSlice}, parsed snapshot data from {@link useSnapshot},
  * and cardinality context from {@link getProcessedMetricInfo} are merged into a
- * single object. The hook returns `null` until every piece of the context is
- * available.
+ * single object. The hook reads the currently inspected snapshot and metric
+ * from the global UI slice rather than requiring them as parameters. The hook
+ * returns `null` until every piece of the context is available.
  *
  * @param simulateDropKey - optional attribute key to simulate dropping for
  * cardinality reduction demonstration.

--- a/src/ui/organisms/MetricInstanceWidget.tsx
+++ b/src/ui/organisms/MetricInstanceWidget.tsx
@@ -8,7 +8,7 @@ import { DataPointInspectorDrawer } from '@/ui/organisms/DataPointInspectorDrawe
  * {@link DataPointInspectorDrawer}.
  *
  * The widget obtains inspector properties using {@link useInspectorProps}
- * based on the provided snapshot and metric identifiers. It keeps track of
+ * based on global UI state for the active snapshot and metric. It keeps track of
  * attribute drop simulation via {@link useDropSimulation} and forwards toggle
  * events from the drawer back to the hook.
  *
@@ -37,7 +37,7 @@ export const MetricInstanceWidget: React.FC<MetricInstanceWidgetProps> = ({
   metricName,
 }) => {
   const [droppedKey, toggleDrop] = useDropSimulation();
-  const inspectorProps = useInspectorProps(snapshotId, metricName, droppedKey);
+  const inspectorProps = useInspectorProps(droppedKey);
 
   const handleSimulateDrop = useCallback(
     (key: string, drop: boolean) => {


### PR DESCRIPTION
## Summary
- rely on global state inside `useInspectorProps`
- update docs accordingly
- adjust `MetricInstanceWidget` call site

## Testing
- `npm run test:unit` *(fails: vitest not found)*