### PR TITLE
Use shared AttributeRow component

### DIFF
--- a/src/ui/organisms/AttributeZone.module.css
+++ b/src/ui/organisms/AttributeZone.module.css
@@ -4,11 +4,10 @@
   gap: 8px;
 }
 
-.grid {
-  display: grid;
-  grid-template-columns: minmax(140px, 30%) 1fr auto;
+.list {
+  display: flex;
+  flex-direction: column;
   gap: 4px;
-  align-items: center;
 }
 
 .key {


### PR DESCRIPTION
## Summary
- refactor AttributeZone to use the reusable AttributeRow molecule
- adjust layout styles for the new row component

## Testing
- `npm run test:unit` *(fails: vitest not found)*