### PR TITLE
Align event names across services

### DIFF
--- a/src/services/eventBus.ts
+++ b/src/services/eventBus.ts
@@ -36,12 +36,16 @@ export type EventMap = {
   /**
    * A metric widget is requesting to inspect a specific metric.
    */
-  'ui.metric.inspectRequest': { metricName: string; snapshotId: string };
+  'ui.metric.inspect': { metricName: string; snapshotId: string };
 
-  /**
-   * Open the data point inspector drawer.
-   */
-  'ui.inspector.openRequest': void;
+  /** Open the data point inspector drawer. */
+  'ui.inspector.open': void;
+
+  /** Close the data point inspector drawer. */
+  'ui.inspector.close': void;
+
+  /** Toggle attribute drop simulation for cardinality analysis. */
+  'ui.cardinality.simulateDrop': { key: string; drop: boolean };
 
   /**
    * Clear all application state.

--- a/src/services/eventListeners.ts
+++ b/src/services/eventListeners.ts
@@ -30,15 +30,15 @@ export function registerEventListeners(): () => void {
   const uiActions = useUiSlice.getState();
 
   // Data events
-  eventBus.on('data.snapshot.parsed', (payload: EventTypes['data.snapshot.parsed']) => {
+  eventBus.on('data.snapshot.loaded', (payload: EventTypes['data.snapshot.loaded']) => {
     metricsActions.addSnapshot(payload.snapshot);
   });
 
-  eventBus.on('data.snapshot.error', (payload: EventTypes['data.snapshot.error']) => {
-    metricsActions.registerError(payload.fileName, payload.error);
+  eventBus.on('data.error', (payload: EventTypes['data.error']) => {
+    metricsActions.registerError(payload.message);
   });
 
-  eventBus.on('data.snapshot.load.start', (payload: EventTypes['data.snapshot.load.start']) => {
+  eventBus.on('data.snapshot.loading', (payload: EventTypes['data.snapshot.loading']) => {
     metricsActions.markLoading(payload.fileName);
   });
 

--- a/src/services/eventTypes.ts
+++ b/src/services/eventTypes.ts
@@ -5,12 +5,12 @@ import type { ParsedSnapshot, SeriesKey } from '@/contracts/types';
  * Maps event names to their payload types.
  */
 export interface EventTypes {
-  'data.snapshot.parsed': { snapshot: ParsedSnapshot };
-  'data.snapshot.error': { fileName: string; error: string };
-  'data.snapshot.load.start': { fileName: string };
-  
-  'ui.inspector.open': { 
-    snapshotId: string; 
+  'data.snapshot.loading': { fileId: string; fileName: string };
+  'data.snapshot.loaded': { snapshot: ParsedSnapshot };
+  'data.error': { message: string; error?: unknown };
+
+  'ui.inspector.open': {
+    snapshotId: string;
     metricName: string;
     seriesKey: SeriesKey;
     pointId: number;

--- a/src/state/metricsSlice.ts
+++ b/src/state/metricsSlice.ts
@@ -23,6 +23,10 @@ export interface MetricsSliceState {
   snapshots: Record<string, ParsedSnapshot>;
   /** Ordered list of snapshot ids in insertion order. */
   snapshotOrder: string[];
+  /** File names currently being loaded. */
+  loading: string[];
+  /** Error messages from snapshot processing. */
+  errors: string[];
 }
 
 /** Actions mutating {@link MetricsSliceState}. */
@@ -33,6 +37,10 @@ export interface MetricsSliceActions {
   removeSnapshot(id: string): void;
   /** Clear all snapshots. */
   clearSnapshots(): void;
+  /** Track a file as loading. */
+  markLoading(fileName: string): void;
+  /** Record an error message. */
+  registerError(message: string): void;
 }
 
 /** Zustand store containing metrics data and actions. */
@@ -40,6 +48,8 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
   immer((set) => ({
     snapshots: {},
     snapshotOrder: [],
+    loading: [],
+    errors: [],
 
     addSnapshot: (snap) =>
       set((state) => {
@@ -59,6 +69,16 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
       set((state) => {
         state.snapshots = {};
         state.snapshotOrder = [];
+      }),
+
+    markLoading: (fileName) =>
+      set((state) => {
+        state.loading.push(fileName);
+      }),
+
+    registerError: (message) =>
+      set((state) => {
+        state.errors.push(message);
       }),
   }))
 );

--- a/tests/eventFlow.test.ts
+++ b/tests/eventFlow.test.ts
@@ -1,0 +1,41 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { bus } from '../src/services/eventBus';
+import { registerEventListeners } from '../src/services/eventListeners';
+import { useMetricsSlice } from '../src/state/metricsSlice';
+
+const sampleSnapshot = {
+  id: 'snap1',
+  fileName: 'file.json',
+  ingestionTimestamp: 0,
+  resources: [],
+};
+
+let cleanup: () => void;
+
+describe('event listener integration', () => {
+  beforeEach(() => {
+    if (cleanup) cleanup();
+    useMetricsSlice.setState({
+      snapshots: {},
+      snapshotOrder: [],
+      loading: [],
+      errors: [],
+    });
+    cleanup = registerEventListeners();
+  });
+
+  it('adds snapshot on loaded event', () => {
+    bus.emit('data.snapshot.loaded', { snapshot: sampleSnapshot });
+    expect(useMetricsSlice.getState().snapshots['snap1']).toEqual(sampleSnapshot);
+  });
+
+  it('tracks loading files', () => {
+    bus.emit('data.snapshot.loading', { fileId: '1', fileName: 'foo.json' });
+    expect(useMetricsSlice.getState().loading).toContain('foo.json');
+  });
+
+  it('records errors', () => {
+    bus.emit('data.error', { message: 'oops' });
+    expect(useMetricsSlice.getState().errors).toContain('oops');
+  });
+});


### PR DESCRIPTION
## Summary
- standardize event names and extend `EventMap`
- sync `EventTypes` with the canonical events
- wire up new names in `registerEventListeners`
- enhance `metricsSlice` with loading/error tracking
- add integration test for event flow

## Testing
- `npm run test:unit` *(fails: vitest not found)*