### PR TITLE
Merge PR #97: Add tsconfig and integrate with Vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "playwright": "^1.37.0",
     "typescript": "^5.1.6",
     "vite": "^6.3.5",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "vite-tsconfig-paths": "^4.2.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,18 @@
-{
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "jsx": "react-jsx",
-    "strict": true,
-    "noEmit": false,
-    "skipLibCheck": false,
-    "baseUrl": "./src",
-    "paths": {
-      "@/*": ["./*"]
-    }
-  },
-  "include": ["src", "tests"],
-  "exclude": ["node_modules", "dist"]
-}
+{  
+  "extends": "@tsconfig/vite/tsconfig.json",  
+  "compilerOptions": {  
+    "jsx": "react-jsx",  
+    "strict": true,  
+    "rootDir": "src",  
+    "noEmit": false,  
+    "skipLibCheck": true,  
+    "baseUrl": "./src",  
+    "paths": {  
+      "@/*": ["./*"]  
+    },  
+    "forceConsistentCasingInFileNames": true,  
+    "types": ["node"]  
+  },  
+  "include": ["src", "tests", "vite.config.js"],  
+  "exclude": ["node_modules", "dist"]  
+} 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
+  plugins: [react(), tsconfigPaths()],
 });


### PR DESCRIPTION
This PR merges the changes from PR #97 with resolved conflicts in tsconfig.json and updated vite.config.js. It adds proper TypeScript configuration to work with Vite and adds the vite-tsconfig-paths plugin for improved path handling.