### PR TITLE
Add worker support check with sync fallback

### DIFF
--- a/src/data/dispatchToWorker.ts
+++ b/src/data/dispatchToWorker.ts
@@ -11,6 +11,9 @@
  */
 
 import type { ParsedSnapshot } from '@/contracts/types';
+import { jsonSafeParse } from '@/logic/workers/utils/jsonSafeParse';
+import { mapToParsedSnapshot } from '@/logic/workers/mapping/otlpMapper';
+import type { RawOtlpExportMetricsServiceRequest } from '@/contracts/rawOtlpTypes';
 
 export interface ParseTask {
   snapshotId: string;
@@ -35,12 +38,56 @@ export type WorkerFailure = {
   payload: ParserErrorPayload;
 };
 
+const workerSupported = (() => {
+  try {
+    return (
+      typeof Worker !== 'undefined' &&
+      typeof URL !== 'undefined' &&
+      typeof import.meta.url === 'string'
+    );
+  } catch {
+    return false;
+  }
+})();
+
 const workers: Worker[] = [];
 const inFlight = new Map<string, { resolve: (r: WorkerSuccess | WorkerFailure) => void }>();
 let rr = 0;
 let poolSize = 0;
 
+async function parseSynchronously(task: ParseTask): Promise<WorkerSuccess | WorkerFailure> {
+  const parsed = jsonSafeParse<RawOtlpExportMetricsServiceRequest>(task.rawJson);
+  if (parsed.type === 'left') {
+    return {
+      type: 'parserError',
+      payload: {
+        snapshotId: task.snapshotId,
+        fileName: task.fileName,
+        message: `JSON parsing failed: ${parsed.value.message}`,
+        detail: parsed.value.stack,
+      },
+    };
+  }
+
+  try {
+    const snapshot = mapToParsedSnapshot(parsed.value, task.snapshotId, task.fileName);
+    return { type: 'parsedSnapshot', payload: snapshot };
+  } catch (err: any) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    return {
+      type: 'parserError',
+      payload: {
+        snapshotId: task.snapshotId,
+        fileName: task.fileName,
+        message: `OTLP mapping failed: ${error.message}`,
+        detail: error.stack,
+      },
+    };
+  }
+}
+
 function ensurePool() {
+  if (!workerSupported) return;
   if (workers.length) return;
   const cores = typeof navigator !== 'undefined' && navigator.hardwareConcurrency ? navigator.hardwareConcurrency : 2;
   poolSize = Math.min(4, Math.max(1, cores - 1));
@@ -66,6 +113,9 @@ function ensurePool() {
  * @returns Promise resolving with the worker result or parser error.
  */
 export function dispatchToParserWorker(task: ParseTask): Promise<WorkerSuccess | WorkerFailure> {
+  if (!workerSupported) {
+    return parseSynchronously(task);
+  }
   ensurePool();
   return new Promise((resolve) => {
     const taskId = crypto.randomUUID();
@@ -83,6 +133,7 @@ export function dispatchToParserWorker(task: ParseTask): Promise<WorkerSuccess |
  * Used during application teardown or hot reloads.
  */
 export function terminateAllParserWorkers(): void {
+  if (!workerSupported) return;
   workers.forEach((w) => w.terminate());
   workers.length = 0;
   inFlight.clear();


### PR DESCRIPTION
## Summary
- check for Worker + URL support when initializing parser workers
- fall back to synchronous parsing when workers aren't available
- no-op terminateAllParserWorkers when workers unsupported

## Testing
- `npm run typecheck` *(fails: cannot find module 'react')*
- `npm run test:unit` *(fails: vitest not found)*