### PR TITLE
Measure AttributeRow height for virtual list

### DIFF
--- a/src/ui/organisms/AttributeZone.tsx
+++ b/src/ui/organisms/AttributeZone.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { AttrMap, AttrValue } from '@/contracts/types';
 import { FixedSizeList } from 'react-window';
 import { AttributeRow } from '../molecules/AttributeRow';
@@ -50,14 +50,27 @@ export const AttributeZone: React.FC<AttributeZoneProps> = ({
   onFocusAttr,
   onAddGlobalFilter
 }) => {
+  const rowRef = useRef<HTMLDivElement>(null);
+  const [itemSize, setItemSize] = useState<number>(36);
+
+  useEffect(() => {
+    if (rowRef.current) {
+      setItemSize(rowRef.current.getBoundingClientRect().height);
+    }
+  }, []);
   const renderRow = useCallback(
-    (key: string, value: AttrValue, style?: React.CSSProperties) => {
+    (
+      key: string,
+      value: AttrValue,
+      style?: React.CSSProperties,
+      ref?: React.Ref<HTMLDivElement>
+    ) => {
       const uniqueCount = attrUniq[key] ?? 0;
       const rarityPercent = seriesCount ? (uniqueCount / seriesCount) * 100 : 0;
       const handleClick = () =>
         focusedAttrKey === key ? onFocusAttr(null) : onFocusAttr(key);
       return (
-        <div style={style} onClick={handleClick}>
+        <div ref={ref} style={style} onClick={handleClick}>
           <AttributeRow
             attrKey={key}
             attrValue={value}
@@ -88,10 +101,10 @@ export const AttributeZone: React.FC<AttributeZoneProps> = ({
           </>
         )}
         <h4>Metric ({metricKeys.length})</h4>
-        <FixedSizeList height={300} width="100%" itemCount={metricKeys.length} itemSize={36}>
+        <FixedSizeList height={300} width="100%" itemCount={metricKeys.length} itemSize={itemSize}>
           {({ index, style }) => {
             const key = metricKeys[index];
-            return renderRow(key, metricAttrs[key], style);
+            return renderRow(key, metricAttrs[key], style, index === 0 ? rowRef : undefined);
           }}
         </FixedSizeList>
       </div>


### PR DESCRIPTION
## Summary
- measure AttributeRow height on mount using `useRef`
- feed measured size to `FixedSizeList`

## Testing
- `pnpm test:unit` *(fails: vitest not found)*