### PR TITLE
Add gauge default color token

### DIFF
--- a/src/design/design-tokens.ts
+++ b/src/design/design-tokens.ts
@@ -70,6 +70,7 @@ export const visualizationSpecificColorsTokens = {
   chipOperatorColor: "#888888",
   chipCountColor: "#aaaaaa",
   chipEqualsColor: "#e0e0e0",
+  gaugeDefaultColor: "#0066CC",
   exemplarDotDefault: "#666666",
   exemplarDotSelected: "#f39c12",
   exemplarAxisColor: "#444444",

--- a/src/design/tokens.css
+++ b/src/design/tokens.css
@@ -51,6 +51,7 @@
   --chipOperatorColor: #888888;
   --chipCountColor: #aaaaaa;
   --chipEqualsColor: #e0e0e0;
+  --gaugeDefaultColor: #0066CC;
   --exemplarDotDefault: #666666;
   --exemplarDotSelected: #f39c12;
   --exemplarAxisColor: #444444;


### PR DESCRIPTION
## Summary
- add `--gaugeDefaultColor` CSS variable
- expose `gaugeDefaultColor` in design tokens

## Testing
- `pnpm install` *(fails: EHOSTUNREACH)*