### PR TITLE
Implement focus trapping in inspector drawer

### DIFF
--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -1,0 +1,55 @@
+import { useEffect } from 'react';
+
+/**
+ * Trap keyboard focus within the referenced container.
+ *
+ * @param ref - Element containing the interactive region
+ */
+export function useFocusTrap(ref: React.RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+
+    const selector = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+
+    const getFocusable = () =>
+      Array.from(container.querySelectorAll<HTMLElement>(selector));
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable();
+      if (focusable.length === 0) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container.addEventListener('keydown', handleKeyDown);
+    // focus container on mount
+    (container as HTMLElement).focus();
+
+    return () => {
+      container.removeEventListener('keydown', handleKeyDown);
+      if (previouslyFocused instanceof HTMLElement) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [ref]);
+}

--- a/src/ui/organisms/DataPointInspectorDrawer.tsx
+++ b/src/ui/organisms/DataPointInspectorDrawer.tsx
@@ -6,6 +6,7 @@ import { CardinalityCapsule } from './CardinalityCapsule';
 import { AttributeZone } from './AttributeZone';
 import { ExemplarsZone } from './ExemplarsZone';
 import { RawJsonZone } from './RawJsonZone';
+import { useFocusTrap } from '@/hooks/useFocusTrap';
 import styles from './DataPointInspectorDrawer.module.css';
 
 /**
@@ -81,10 +82,8 @@ export const DataPointInspectorDrawer: React.FC<DataPointInspectorDrawerProps> =
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  // Auto focus when mounted
-  useEffect(() => {
-    drawerRef.current?.focus();
-  }, []);
+  // Trap focus inside drawer while mounted
+  useFocusTrap(drawerRef);
 
   const memoizedAttributeZone = useMemo(
     () => (


### PR DESCRIPTION
## Summary
- add minimal `useFocusTrap` hook to manage focus trapping
- apply focus trap to `DataPointInspectorDrawer`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find configuration)*
- `pnpm test:unit` *(fails: vitest not found)*