### PR TITLE
Remove unused snapshotId prop

### DIFF
--- a/src/ui/organisms/MetricInstanceWidget.tsx
+++ b/src/ui/organisms/MetricInstanceWidget.tsx
@@ -16,8 +16,6 @@ import { DataPointInspectorDrawer } from '@/ui/organisms/DataPointInspectorDrawe
  * allowing parent components to omit the inspector until context is ready.
  */
 export interface MetricInstanceWidgetProps {
-  /** Identifier of the {@link ParsedSnapshot} to read from. */
-  snapshotId: string;
   /** Metric key within the snapshot. */
   metricName: string;
 }
@@ -33,7 +31,6 @@ export interface MetricInstanceWidgetProps {
  * counts stay in sync.
  */
 export const MetricInstanceWidget: React.FC<MetricInstanceWidgetProps> = ({
-  snapshotId,
   metricName,
 }) => {
   const [droppedKey, toggleDrop] = useDropSimulation();


### PR DESCRIPTION
## Summary
- clean up MetricInstanceWidget by removing the unused `snapshotId` prop

## Testing
- `pnpm test:unit` *(fails: vitest not found)*