### PR TITLE
Fix gzip decompression import

### DIFF
--- a/src/data/readFile.ts
+++ b/src/data/readFile.ts
@@ -1,12 +1,12 @@
 import { ValidFile } from './fileValidator';
-import { decompressGzipToString } from './decompressGzip';
+import { decompressGzip } from './decompressGzip';
 
 /**
  * Turn a validated File into a UTF-8 string ready for JSON parsing.
  *
  * The file is read as an `ArrayBuffer` using the DOM `FileReader` API. If the
  * provided {@link ValidFile} indicates a gzipped file, the buffer is inflated
- * via {@link decompressGzipToString}. Otherwise the buffer is decoded directly
+ * via {@link decompressGzip}. Otherwise the buffer is decoded directly
  * with `TextDecoder('utf-8')`. Any read or decompression failure rejects the
  * returned promise with an `Error`.
  *
@@ -15,7 +15,7 @@ import { decompressGzipToString } from './decompressGzip';
  * @throws Error if the browser fails to read the file or if decompression
  * throws.
  *
- * @dependency {@link decompressGzipToString}
+ * @dependency {@link decompressGzip}
  * @consumers `dispatchToWorker.ts`, `StaticFileProvider.tsx`
  */
 export async function readFileContent(vf: ValidFile): Promise<string> {
@@ -26,7 +26,7 @@ export async function readFileContent(vf: ValidFile): Promise<string> {
       const buffer = reader.result as ArrayBuffer;
       try {
         if (vf.isGzipped) {
-          const text = await decompressGzipToString(buffer);
+          const text = await decompressGzip(buffer);
           resolve(text);
         } else {
           const text = new TextDecoder('utf-8').decode(buffer);


### PR DESCRIPTION
## Summary
- use `decompressGzip` in `readFileContent`
- update documentation references

## Testing
- `npm run build` *(fails: vite: not found)*