### PR TITLE
Add canonical header to design tokens

### DIFF
--- a/src/design/design-tokens.ts
+++ b/src/design/design-tokens.ts
@@ -1,4 +1,11 @@
 /**
+ * @file design-tokens.ts
+ * @summary Typed mirror of `tokens.css` design tokens.
+ * @remarks Styling code should reference `tokens.css` variables via `var(--name)`.
+ * @layer design
+ * @perfBudget N/A
+ * @loc_estimate 202
+ *
  * IntelliMetric Explorer – Design Tokens
  *
  * Centralized constants mirroring the CSS variables in `tokens.css`.


### PR DESCRIPTION
## Summary
- add a canonical docblock header to `design-tokens.ts`

## Testing
- `git status --short`