### PR TITLE
Add randomId helper with crypto fallback

### DIFF
--- a/src/data/StaticFileProvider.tsx
+++ b/src/data/StaticFileProvider.tsx
@@ -5,6 +5,7 @@ import { bus } from '../services/eventBus';
 import { validateFile, ValidFile } from './fileValidator';
 import { readFileContent } from './readFile';
 import { dispatchToParserWorker } from './dispatchToWorker';
+import { randomId } from '@/utils/randomId';
 
 /**
  * Props for {@link StaticFileProvider}.
@@ -53,7 +54,7 @@ export function StaticFileProvider({
   const handleFiles = useCallback(
     async (files: FileList) => {
       for (const file of Array.from(files)) {
-        const id = crypto.randomUUID();
+        const id = randomId();
         const snapshotId = `snap-${id}`;
         setStatus((s) => ({ ...s, [id]: `\u{1F680} reading … ${file.name}` }));
         bus.emit('data.snapshot.load.start', { fileName: file.name });

--- a/src/data/dispatchToWorker.ts
+++ b/src/data/dispatchToWorker.ts
@@ -4,13 +4,14 @@
  *
  * @remarks
  * Algorithm: maintain a singleton array of workers and dispatch tasks in round-robin.
- * Dependencies: browser `Worker`, `crypto.randomUUID`, `parser.worker.ts` bundle path.
+ * Dependencies: browser `Worker`, {@link randomId}, `parser.worker.ts` bundle path.
  * Consumers: StaticFileProvider and future bulk-import features.
  * Tests: mocked Worker to validate success, failure, round-robin, and termination.
  * Future work: queue length metrics and dynamic pool sizing.
  */
 
 import type { ParsedSnapshot } from '@/contracts/types';
+import { randomId } from '@/utils/randomId';
 
 export interface ParseTask {
   snapshotId: string;
@@ -68,7 +69,7 @@ function ensurePool() {
 export function dispatchToParserWorker(task: ParseTask): Promise<WorkerSuccess | WorkerFailure> {
   ensurePool();
   return new Promise((resolve) => {
-    const taskId = crypto.randomUUID();
+    const taskId = randomId();
     inFlight.set(taskId, { resolve });
     const worker = workers[rr];
     worker.postMessage({ taskId, type: 'parse', payload: task });

--- a/src/utils/randomId.ts
+++ b/src/utils/randomId.ts
@@ -1,0 +1,34 @@
+/**
+ * Generate a UUID string using the best available method.
+ *
+ * Uses `crypto.randomUUID` when present. Falls back to a small RFC4122 v4
+ * implementation when unavailable.
+ */
+export function randomId(): string {
+  if (typeof crypto !== 'undefined') {
+    if (typeof (crypto as any).randomUUID === 'function') {
+      return (crypto as any).randomUUID();
+    }
+    const bytes = new Uint8Array(16);
+    if (typeof crypto.getRandomValues === 'function') {
+      crypto.getRandomValues(bytes);
+    } else {
+      for (let i = 0; i < bytes.length; i += 1) {
+        bytes[i] = Math.floor(Math.random() * 256);
+      }
+    }
+    // set bits for version and `clock_seq_hi_and_reserved`
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex = Array.from(bytes).map((b) => b.toString(16).padStart(2, '0'));
+    return (
+      `${hex[0]}${hex[1]}${hex[2]}${hex[3]}-` +
+      `${hex[4]}${hex[5]}-` +
+      `${hex[6]}${hex[7]}-` +
+      `${hex[8]}${hex[9]}-` +
+      `${hex[10]}${hex[11]}${hex[12]}${hex[13]}${hex[14]}${hex[15]}`
+    );
+  }
+  // Fallback when crypto is unavailable
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}

--- a/tests/randomId.test.ts
+++ b/tests/randomId.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest';
+import { randomId } from '../src/utils/randomId';
+
+describe('randomId', () => {
+  it('uses crypto.randomUUID when available', () => {
+    const original = globalThis.crypto;
+    const mock = vi.fn().mockReturnValue('abc-123');
+    (globalThis as any).crypto = { ...original, randomUUID: mock, getRandomValues: original?.getRandomValues };
+
+    const id = randomId();
+    expect(id).toBe('abc-123');
+    expect(mock).toHaveBeenCalled();
+    (globalThis as any).crypto = original;
+  });
+
+  it('falls back when randomUUID is missing', () => {
+    const original = globalThis.crypto;
+    (globalThis as any).crypto = { getRandomValues: vi.fn() };
+
+    const id = randomId();
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+
+    (globalThis as any).crypto = original;
+  });
+});


### PR DESCRIPTION
## Summary
- provide `randomId` util with fallback when `crypto.randomUUID` is missing
- use `randomId` in worker dispatch and file provider
- test helper behaviour

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run test:unit` *(fails: vitest not found)*