### PR TITLE
Remove global drop simulation state

### DIFF
--- a/src/services/eventBus.ts
+++ b/src/services/eventBus.ts
@@ -54,15 +54,10 @@ export type EventMap = {
   'ui.inspector.close': void;
 
   /**
-   * Toggle cardinality drop simulation for a metric.
-   */
-  'ui.cardinality.simulateDrop': { key: string; drop: boolean };
-
-  /**
    * Clear all application state.
    */
   'app.reset': void;
-};
+}; 
 
 /**
  * Global mitt-based event channel for decoupled communication.

--- a/src/services/eventListeners.ts
+++ b/src/services/eventListeners.ts
@@ -60,14 +60,6 @@ export function registerEventListeners(): () => void {
     uiActions.inspectMetric(payload.metricName);
   });
 
-  // Cardinality simulation toggle
-  eventBus.on(
-    'ui.cardinality.simulateDrop',
-    (payload: EventTypes['ui.cardinality.simulateDrop']) => {
-      uiActions.toggleSimDrop(payload.key, payload.drop);
-    }
-  );
-
   // Return cleanup function to detach all listeners
   return () => {
     eventBus.off('*');

--- a/src/services/eventTypes.ts
+++ b/src/services/eventTypes.ts
@@ -17,5 +17,4 @@ export interface EventTypes {
   };
   'ui.inspector.close': void;
   'ui.metric.inspect': { snapshotId: string; metricName: string };
-  'ui.cardinality.simulateDrop': { key: string; drop: boolean };
 }

--- a/src/state/uiSlice.ts
+++ b/src/state/uiSlice.ts
@@ -5,7 +5,6 @@
  * - Stores IDs for active/baseline/comparison snapshots
  * - Tracks metric, series and point currently inspected
  * - Controls inspector drawer visibility and dashboard filter
- * - Maintains drop simulation state for cardinality analysis
  *
  * @dependencies Zustand with immer middleware
  * @packageDocumentation
@@ -27,10 +26,6 @@ export interface UiSliceState {
 
   isInspectorOpen: boolean;
   dashboardFilter: string;
-  dropSimulation?: {
-    attributeKey: string | null;
-    isActive: boolean;
-  };
 }
 
 /** Actions to mutate UI slice state. */
@@ -46,7 +41,6 @@ export interface UiSliceActions {
   closeInspector(): void;
 
   setDashboardFilter(text: string): void;
-  toggleSimDrop(key: string, drop: boolean): void;
 
   resetUi(): void;
 }
@@ -64,7 +58,6 @@ export const useUiSlice = create<UiSliceState & UiSliceActions>()(
 
     isInspectorOpen: false,
     dashboardFilter: '',
-    dropSimulation: undefined,
 
     setActiveSnapshot: id => set(s => { s.activeSnapshotId = id; }),
     setSnapshotRoleA: id => set(s => { s.snapshotAId = id; }),
@@ -80,13 +73,6 @@ export const useUiSlice = create<UiSliceState & UiSliceActions>()(
     closeInspector: () => set(s => { s.isInspectorOpen = false; }),
 
     setDashboardFilter: text => set(s => { s.dashboardFilter = text; }),
-    toggleSimDrop: (key, drop) => set(s => {
-      if (drop) {
-        s.dropSimulation = { attributeKey: key, isActive: true };
-      } else if (s.dropSimulation?.attributeKey === key) {
-        s.dropSimulation = undefined;
-      }
-    }),
 
     resetUi: () => set(s => {
       s.activeSnapshotId = null;
@@ -97,7 +83,6 @@ export const useUiSlice = create<UiSliceState & UiSliceActions>()(
       s.inspectedPointId = null;
       s.isInspectorOpen = false;
       s.dashboardFilter = '';
-      s.dropSimulation = undefined;
     })
   }))
 );
@@ -115,8 +100,5 @@ export const selectCurrentInspectionContext = (state: UiSliceState) => ({
   seriesKey: state.inspectedSeriesKey,
   pointId: state.inspectedPointId
 });
-
-/** Selector for active drop simulation settings. */
-export const selectDropSimulation = (state: UiSliceState) => state.dropSimulation;
 
 export default useUiSlice;

--- a/tests/uiSlice.test.ts
+++ b/tests/uiSlice.test.ts
@@ -1,7 +1,6 @@
 import { describe, beforeEach, it, expect } from 'vitest';
 import useUiSlice, {
   selectIsInspectorOpen,
-  selectDropSimulation,
   selectCurrentInspectionContext
 } from '../src/state/uiSlice';
 
@@ -26,16 +25,6 @@ describe('uiSlice', () => {
     const ctx = selectCurrentInspectionContext(useUiSlice.getState());
     expect(ctx.seriesKey).toBe('metric|a=b');
     expect(ctx.pointId).toBe(123);
-  });
-
-  it('toggleSimDrop sets and clears simulation', () => {
-    useUiSlice.getState().toggleSimDrop('http.method', true);
-    expect(selectDropSimulation(useUiSlice.getState())).toEqual({
-      attributeKey: 'http.method',
-      isActive: true
-    });
-    useUiSlice.getState().toggleSimDrop('http.method', false);
-    expect(selectDropSimulation(useUiSlice.getState())).toBeUndefined();
   });
 
   it('resetUi clears values', () => {


### PR DESCRIPTION
## Summary
- delete dropSimulation state and selector
- remove simulateDrop event handling
- drop toggleSimDrop action and tests

## Testing
- `pnpm test:unit` *(fails: vitest not found)*