### PR TITLE
Enable keyboard access for attribute rows

### DIFF
--- a/src/ui/organisms/AttributeZone.tsx
+++ b/src/ui/organisms/AttributeZone.tsx
@@ -56,8 +56,20 @@ export const AttributeZone: React.FC<AttributeZoneProps> = ({
       const rarityPercent = seriesCount ? (uniqueCount / seriesCount) * 100 : 0;
       const handleClick = () =>
         focusedAttrKey === key ? onFocusAttr(null) : onFocusAttr(key);
+      const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      };
       return (
-        <div style={style} onClick={handleClick}>
+        <div
+          style={style}
+          onClick={handleClick}
+          role="button"
+          tabIndex={0}
+          onKeyDown={handleKeyDown}
+        >
           <AttributeRow
             attrKey={key}
             attrValue={value}

--- a/src/ui/organisms/CardinalityCapsule.tsx
+++ b/src/ui/organisms/CardinalityCapsule.tsx
@@ -117,6 +117,14 @@ export const CardinalityCapsule: React.FC<CardinalityCapsuleProps> = ({
                 focusedAttrKey === attr ? styles.focused : ''
               }`}
               onClick={() => onFocusAttr(focusedAttrKey === attr ? null : attr)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onFocusAttr(focusedAttrKey === attr ? null : attr);
+                }
+              }}
             >
               <div className={styles.attrName}>{attr}</div>
               <div className={styles.barContainer}>

--- a/tests/AttributeZone.test.tsx
+++ b/tests/AttributeZone.test.tsx
@@ -35,4 +35,24 @@ describe('AttributeZone', () => {
     fireEvent.click(screen.getByText('method'));
     expect(onFocusAttr).toHaveBeenCalledWith('method');
   });
+
+  it('calls onFocusAttr when row activated via keyboard', () => {
+    const onFocusAttr = vi.fn();
+    const props = {
+      resourceAttrs: {},
+      metricAttrs: { method: 'GET' },
+      attrUniq: { method: 1 },
+      seriesCount: 10,
+      focusedAttrKey: null,
+      onAddGlobalFilter: undefined as any,
+      onFocusAttr,
+    };
+    render(<AttributeZone {...props} />);
+    const row = screen.getByText('method').parentElement as HTMLElement;
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(onFocusAttr).toHaveBeenCalledWith('method');
+    onFocusAttr.mockClear();
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(onFocusAttr).toHaveBeenCalledWith('method');
+  });
 });

--- a/tests/CardinalityCapsule.test.tsx
+++ b/tests/CardinalityCapsule.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { CardinalityCapsule } from '../src/ui/organisms/CardinalityCapsule';
+
+describe('CardinalityCapsule', () => {
+  it('calls onFocusAttr when mini-bar row activated via keyboard', () => {
+    const onFocusAttr = vi.fn();
+    render(
+      <CardinalityCapsule
+        seriesCount={10}
+        thresholdHigh={100}
+        attrRank={['method']}
+        attrUniq={{ method: 1 }}
+        focusedAttrKey={null}
+        onFocusAttr={onFocusAttr}
+        onToggleDrop={vi.fn()}
+        isDropSimActive={false}
+        droppedKey={null}
+      />
+    );
+
+    const row = screen.getByText('method').parentElement as HTMLElement;
+    fireEvent.keyDown(row, { key: 'Enter' });
+    expect(onFocusAttr).toHaveBeenCalledWith('method');
+    onFocusAttr.mockClear();
+    fireEvent.keyDown(row, { key: ' ' });
+    expect(onFocusAttr).toHaveBeenCalledWith('method');
+  });
+});
+


### PR DESCRIPTION
## Summary
- make attribute rows keyboard accessible
- make mini-bar rows keyboard accessible
- test keyboard interaction for AttributeZone
- test keyboard interaction for CardinalityCapsule

## Testing
- `pnpm test:unit` *(fails: vitest not found)*