### PR TITLE
Add ESLint config and Husky pre-push hook

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+    node: true,
+  },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    project: ['./tsconfig.json'],
+    sourceType: 'module',
+  },
+  plugins: ['@typescript-eslint', 'import', 'react'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'plugin:react/recommended',
+  ],
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+};

--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ -n "$HUSKY_DEBUG" ] && echo "husky: $*"
+  }
+
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+
+  if [ "$HUSKY" = "0" ]; then
+    debug "HUSKY env variable is set to 0, skipping hook" && exit 0
+  fi
+
+  if [ -f ~/.huskyrc ]; then
+    debug "~/.huskyrc found, sourcing..."
+    . ~/.huskyrc
+  fi
+
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode="$?"
+  debug "$hook_name finished with exit code $exitCode"
+  exit "$exitCode"
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+pnpm lint && pnpm test:unit -- --ci

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:storybook": "storybook build",
     "docs:mkdocs": "mkdocs build --config-file mkdocs.yml",
     "release": "semantic-release",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "prepare": "husky install"
   },
   "dependencies": {
     "mitt": "^3.0.1",
@@ -42,6 +43,10 @@
     "playwright": "^1.37.0",
     "typescript": "^5.1.6",
     "vite": "^6.3.5",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
+    "eslint-plugin-import": "^2.29.1",
+    "husky": "^9.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- add `.eslintrc.cjs` config with `@typescript-eslint` and `eslint-plugin-import`
- configure Husky pre-push hook to run linting and unit tests
- declare Husky and ESLint plugins in `package.json`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*