### PR TITLE
Add icons and tokens for instrument badge

### DIFF
--- a/src/design/design-tokens.ts
+++ b/src/design/design-tokens.ts
@@ -81,6 +81,15 @@ export const visualizationSpecificColorsTokens = {
   simulationBg: "rgba(0, 120, 212, 0.1)",
 } as const;
 
+/** Background colours for instrument badges. */
+export const instrumentBadgeTokens = {
+  instrumentGaugeBg: "#3498db",
+  instrumentSumBg: "#2ecc71",
+  instrumentHistogramBg: "#f39c12",
+  instrumentSummaryBg: "#9b59b6",
+  instrumentUnknownBg: "#666666",
+} as const;
+
 /** Spacing scale and component padding values. */
 export const spacingTokens = {
   spaceXS: "4px",

--- a/src/design/tokens.css
+++ b/src/design/tokens.css
@@ -61,6 +61,12 @@
   --rarityHigh: #e74c3c;
   --simulationBg: rgba(0, 120, 212, 0.1);
 
+  --instrumentGaugeBg: #3498db;
+  --instrumentSumBg: #2ecc71;
+  --instrumentHistogramBg: #f39c12;
+  --instrumentSummaryBg: #9b59b6;
+  --instrumentUnknownBg: #666666;
+
   --spaceXS: 4px;
   --spaceS: 8px;
   --spaceM: 16px;

--- a/src/ui/atoms/InstrumentBadge.module.css
+++ b/src/ui/atoms/InstrumentBadge.module.css
@@ -2,11 +2,30 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background-color: var(--cardBg);
   color: var(--textPrimary);
   border-radius: 4px;
   font-weight: 500;
   text-transform: uppercase;
+}
+
+.gauge {
+  background-color: var(--instrumentGaugeBg);
+}
+
+.sum {
+  background-color: var(--instrumentSumBg);
+}
+
+.histogram {
+  background-color: var(--instrumentHistogramBg);
+}
+
+.summary {
+  background-color: var(--instrumentSummaryBg);
+}
+
+.unknown {
+  background-color: var(--instrumentUnknownBg);
 }
 
 .small {

--- a/src/ui/atoms/InstrumentBadge.tsx
+++ b/src/ui/atoms/InstrumentBadge.tsx
@@ -1,8 +1,22 @@
 import React from 'react';
 import clsx from 'clsx';
+import {
+  GaugeCircle,
+  Plus,
+  BarChart2,
+  List,
+  HelpCircle,
+} from 'lucide-react';
 import styles from './InstrumentBadge.module.css';
 import type { MetricDefinition } from '@/contracts/types';
 
+/**
+ * Props for {@link InstrumentBadge}.
+ *
+ * @property type - Metric instrument type used to choose icon and colour.
+ * @property size - Badge dimensions, `'small'` or `'large'` (default).
+ * @property className - Optional extra class for the badge element.
+ */
 export interface InstrumentBadgeProps {
   type: MetricDefinition['instrumentType'];
   size?: 'small' | 'large';
@@ -15,7 +29,36 @@ export const InstrumentBadge: React.FC<InstrumentBadgeProps> = ({
   className,
 }) => {
   const sizeClass = size === 'small' ? styles.small : styles.large;
+  const iconSize = size === 'small' ? 12 : 16;
+
+  const Icon =
+    type === 'Gauge'
+      ? GaugeCircle
+      : type === 'Sum'
+      ? Plus
+      : type === 'Histogram'
+      ? BarChart2
+      : type === 'Summary'
+      ? List
+      : HelpCircle;
+
+  const typeClass =
+    type === 'Gauge'
+      ? styles.gauge
+      : type === 'Sum'
+      ? styles.sum
+      : type === 'Histogram'
+      ? styles.histogram
+      : type === 'Summary'
+      ? styles.summary
+      : styles.unknown;
+
   return (
-    <span className={clsx(styles.badge, sizeClass, className)}>{type}</span>
+    <span
+      className={clsx(styles.badge, typeClass, sizeClass, className)}
+      aria-label={type}
+    >
+      <Icon size={iconSize} aria-hidden />
+    </span>
   );
 };

--- a/tests/InstrumentBadge.test.tsx
+++ b/tests/InstrumentBadge.test.tsx
@@ -4,8 +4,9 @@ import { describe, it, expect } from 'vitest';
 import { InstrumentBadge } from '../src/ui/atoms/InstrumentBadge';
 
 describe('InstrumentBadge', () => {
-  it('renders the provided type', () => {
+  it('renders an icon for the type', () => {
     render(<InstrumentBadge type="Histogram" />);
-    expect(screen.getByText('Histogram')).toBeInTheDocument();
+    const badge = screen.getByLabelText('Histogram');
+    expect(badge.querySelector('svg')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- style instrument badges with Lucide icons
- add token-based background colors
- document props for InstrumentBadge
- verify icon rendering in tests

## Testing
- `pnpm test:unit` *(fails: vitest not found)*