### PR TITLE
Remove unused filter callback

### DIFF
--- a/src/ui/molecules/AttributeRow.tsx
+++ b/src/ui/molecules/AttributeRow.tsx
@@ -9,7 +9,6 @@ export interface AttributeRowProps {
   attrValue: AttrValue;
   rarityPercent: number;
   isFocused?: boolean;
-  onAddGlobalFilter?: () => void;
   className?: string;
 }
 
@@ -18,7 +17,6 @@ export const AttributeRow: React.FC<AttributeRowProps> = ({
   attrValue,
   rarityPercent,
   isFocused = false,
-  onAddGlobalFilter,
   className,
 }) => {
   return (
@@ -36,11 +34,6 @@ export const AttributeRow: React.FC<AttributeRowProps> = ({
           copyValue={String(attrValue)}
           ariaLabel={`Copy value: ${String(attrValue)}`}
         />
-        {onAddGlobalFilter && (
-          <button onClick={onAddGlobalFilter} data-testid="filter-button">
-            Filter
-          </button>
-        )}
       </div>
     </div>
   );

--- a/src/ui/organisms/AttributeZone.tsx
+++ b/src/ui/organisms/AttributeZone.tsx
@@ -33,9 +33,6 @@ export interface AttributeZoneProps {
 
   /** Callback when attribute focus changes */
   onFocusAttr: (key: string | null) => void;
-
-  /** Optional callback to add global filter for attribute */
-  onAddGlobalFilter?: (key: string, value: AttrValue) => void;
 }
 
 /**
@@ -47,8 +44,7 @@ export const AttributeZone: React.FC<AttributeZoneProps> = ({
   attrUniq,
   seriesCount,
   focusedAttrKey,
-  onFocusAttr,
-  onAddGlobalFilter
+  onFocusAttr
 }) => {
   const renderRow = useCallback(
     (key: string, value: AttrValue, style?: React.CSSProperties) => {
@@ -63,14 +59,11 @@ export const AttributeZone: React.FC<AttributeZoneProps> = ({
             attrValue={value}
             rarityPercent={rarityPercent}
             isFocused={focusedAttrKey === key}
-            onAddGlobalFilter={
-              onAddGlobalFilter ? () => onAddGlobalFilter(key, value) : undefined
-            }
           />
         </div>
       );
     },
-    [attrUniq, seriesCount, focusedAttrKey, onAddGlobalFilter, onFocusAttr]
+    [attrUniq, seriesCount, focusedAttrKey, onFocusAttr]
   );
 
   const metricKeys = Object.keys(metricAttrs);

--- a/src/ui/organisms/DataPointInspectorDrawer.tsx
+++ b/src/ui/organisms/DataPointInspectorDrawer.tsx
@@ -50,7 +50,6 @@ export const DataPointInspectorDrawer: React.FC<DataPointInspectorDrawerProps> =
   cardinality,
   exemplars,
   onClose,
-  onAddGlobalFilter,
   onSimulateDrop,
   metricLatestNValues,
   className,
@@ -95,7 +94,6 @@ export const DataPointInspectorDrawer: React.FC<DataPointInspectorDrawerProps> =
         seriesCount={cardinality.seriesCount}
         focusedAttrKey={focusedAttrKey}
         onFocusAttr={setFocusedAttrKey}
-        onAddGlobalFilter={onAddGlobalFilter}
       />
     ),
     [
@@ -104,7 +102,6 @@ export const DataPointInspectorDrawer: React.FC<DataPointInspectorDrawerProps> =
       cardinality.attrUniq,
       cardinality.seriesCount,
       focusedAttrKey,
-      onAddGlobalFilter,
     ]
   );
 

--- a/tests/AttributeZone.test.tsx
+++ b/tests/AttributeZone.test.tsx
@@ -9,7 +9,6 @@ const baseProps = {
   attrUniq: { env: 2, method: 5 },
   seriesCount: 10,
   focusedAttrKey: null as string | null,
-  onAddGlobalFilter: undefined as any,
 };
 
 describe('AttributeZone', () => {
@@ -28,7 +27,6 @@ describe('AttributeZone', () => {
       attrUniq: { method: 1 },
       seriesCount: 10,
       focusedAttrKey: null,
-      onAddGlobalFilter: undefined as any,
       onFocusAttr,
     };
     render(<AttributeZone {...props} />);


### PR DESCRIPTION
## Summary
- confirm filter feature out-of-scope via project scope docs
- remove `onAddGlobalFilter` prop from `AttributeRow` and `AttributeZone`
- stop forwarding unused prop in `DataPointInspectorDrawer`
- update unit tests

## Testing
- `npm run test:unit` *(fails: `vitest: not found`)*