### PR TITLE
Update global filter callback

### DIFF
--- a/src/contracts/types.ts
+++ b/src/contracts/types.ts
@@ -196,8 +196,9 @@ export interface InspectorProps {
   /** Close the inspector UI. */
   onClose: () => void;
   /**
-   * Request the host UI to add a corresponding filter chip. Optional in
-   * Inspector v1.1 and subject to later adoption.
+   * Request the host UI to add a corresponding filter chip using
+   * `key=value` text. Returns nothing. Optional in Inspector v1.1
+   * and subject to later adoption.
    */
   onAddGlobalFilter?: (key: string, value: AttrValue) => void;
   /** Simulate dropping or restoring an attribute. */

--- a/src/hooks/useInspectorProps.ts
+++ b/src/hooks/useInspectorProps.ts
@@ -84,7 +84,8 @@ export function useInspectorProps(simulateDropKey?: string | null): InspectorPro
       },
       exemplars: point.exemplars,
       onClose: closeInspector,
-      onAddGlobalFilter: setDashboardFilter,
+      onAddGlobalFilter: (key, value) =>
+        setDashboardFilter(`${key}=${String(value)}`),
       metricLatestNValues: undefined,
     };
 

--- a/src/ui/organisms/AttributeZone.tsx
+++ b/src/ui/organisms/AttributeZone.tsx
@@ -34,7 +34,10 @@ export interface AttributeZoneProps {
   /** Callback when attribute focus changes */
   onFocusAttr: (key: string | null) => void;
 
-  /** Optional callback to add global filter for attribute */
+  /**
+   * Optional callback to set global filter text from the selected
+   * attribute using `key=value` format.
+   */
   onAddGlobalFilter?: (key: string, value: AttrValue) => void;
 }
 


### PR DESCRIPTION
## Summary
- convert `onAddGlobalFilter` handler to build `key=value` text
- expand docs for the callback in the public types
- clarify callback description for `AttributeZone`

## Testing
- `npm run test:unit` *(fails: vitest not found)*