### PR TITLE
Add loading/error tracking to metrics slice

### DIFF
--- a/src/state/metricsSlice.ts
+++ b/src/state/metricsSlice.ts
@@ -23,6 +23,10 @@ export interface MetricsSliceState {
   snapshots: Record<string, ParsedSnapshot>;
   /** Ordered list of snapshot ids in insertion order. */
   snapshotOrder: string[];
+  /** Files currently being loaded keyed by file name. */
+  loading: Record<string, boolean>;
+  /** Errors encountered while loading keyed by file name. */
+  errors: Record<string, string>;
 }
 
 /** Actions mutating {@link MetricsSliceState}. */
@@ -33,6 +37,10 @@ export interface MetricsSliceActions {
   removeSnapshot(id: string): void;
   /** Clear all snapshots. */
   clearSnapshots(): void;
+  /** Record an error for a given file. */
+  registerError(fileName: string, error: string): void;
+  /** Mark a file as currently loading. */
+  markLoading(fileName: string): void;
 }
 
 /** Zustand store containing metrics data and actions. */
@@ -40,6 +48,8 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
   immer((set) => ({
     snapshots: {},
     snapshotOrder: [],
+    loading: {},
+    errors: {},
 
     addSnapshot: (snap) =>
       set((state) => {
@@ -47,6 +57,8 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
         if (!state.snapshotOrder.includes(snap.id)) {
           state.snapshotOrder.push(snap.id);
         }
+        delete state.loading[snap.fileName];
+        delete state.errors[snap.fileName];
       }),
 
     removeSnapshot: (id) =>
@@ -59,6 +71,20 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
       set((state) => {
         state.snapshots = {};
         state.snapshotOrder = [];
+        state.loading = {};
+        state.errors = {};
+      }),
+
+    registerError: (fileName, error) =>
+      set((state) => {
+        state.errors[fileName] = error;
+        delete state.loading[fileName];
+      }),
+
+    markLoading: (fileName) =>
+      set((state) => {
+        state.loading[fileName] = true;
+        delete state.errors[fileName];
       }),
   }))
 );

--- a/tests/metricsSlice.test.ts
+++ b/tests/metricsSlice.test.ts
@@ -1,0 +1,43 @@
+import { describe, beforeEach, it, expect } from 'vitest';
+import { useMetricsSlice } from '../src/state/metricsSlice';
+import type { ParsedSnapshot } from '../src/contracts/types';
+
+function makeSnapshot(id: string, fileName: string): ParsedSnapshot {
+  return {
+    id,
+    fileName,
+    ingestionTimestamp: 0,
+    resources: [],
+  };
+}
+
+describe('metricsSlice', () => {
+  beforeEach(() => {
+    useMetricsSlice.getState().clearSnapshots();
+  });
+
+  it('markLoading tracks file name', () => {
+    useMetricsSlice.getState().markLoading('foo.json');
+    expect(useMetricsSlice.getState().loading['foo.json']).toBe(true);
+  });
+
+  it('registerError records message and clears loading', () => {
+    const actions = useMetricsSlice.getState();
+    actions.markLoading('bar.json');
+    actions.registerError('bar.json', 'oops');
+    const state = useMetricsSlice.getState();
+    expect(state.errors['bar.json']).toBe('oops');
+    expect(state.loading['bar.json']).toBeUndefined();
+  });
+
+  it('addSnapshot clears status for its file', () => {
+    const actions = useMetricsSlice.getState();
+    actions.markLoading('baz.json');
+    actions.registerError('baz.json', 'err');
+    actions.addSnapshot(makeSnapshot('id1', 'baz.json'));
+    const state = useMetricsSlice.getState();
+    expect(state.snapshots['id1']).toBeDefined();
+    expect(state.errors['baz.json']).toBeUndefined();
+    expect(state.loading['baz.json']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- track snapshot loading and error state in metrics slice
- expose registerError and markLoading actions
- store loading/error states with snapshot actions
- add tests for metrics slice

## Testing
- `pnpm test:unit` *(fails: vitest not found)*