### PR TITLE
Add loading/error state tracking

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,8 +6,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-
-// import { registerGlobalEventListeners } from '@/services/eventListeners';
+import { registerEventListeners } from '@/services/eventListeners';
 import App from './App';
 import './global.css';
 
@@ -23,7 +22,6 @@ root.render(
   </React.StrictMode>
 );
 
-// Commented out to avoid errors during build
-// registerGlobalEventListeners();
+registerEventListeners();
 
 

--- a/src/state/metricsSlice.ts
+++ b/src/state/metricsSlice.ts
@@ -23,6 +23,10 @@ export interface MetricsSliceState {
   snapshots: Record<string, ParsedSnapshot>;
   /** Ordered list of snapshot ids in insertion order. */
   snapshotOrder: string[];
+  /** File names currently being loaded. */
+  loading: Record<string, boolean>;
+  /** Errors keyed by file name. */
+  errors: Record<string, string>;
 }
 
 /** Actions mutating {@link MetricsSliceState}. */
@@ -33,6 +37,10 @@ export interface MetricsSliceActions {
   removeSnapshot(id: string): void;
   /** Clear all snapshots. */
   clearSnapshots(): void;
+  /** Mark a file name as currently loading. */
+  markLoading(fileName: string): void;
+  /** Register a loading or parsing error for a file name. */
+  registerError(fileName: string, error: string): void;
 }
 
 /** Zustand store containing metrics data and actions. */
@@ -40,6 +48,8 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
   immer((set) => ({
     snapshots: {},
     snapshotOrder: [],
+    loading: {},
+    errors: {},
 
     addSnapshot: (snap) =>
       set((state) => {
@@ -47,10 +57,17 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
         if (!state.snapshotOrder.includes(snap.id)) {
           state.snapshotOrder.push(snap.id);
         }
+        delete state.loading[snap.fileName];
+        delete state.errors[snap.fileName];
       }),
 
     removeSnapshot: (id) =>
       set((state) => {
+        const snap = state.snapshots[id];
+        if (snap) {
+          delete state.loading[snap.fileName];
+          delete state.errors[snap.fileName];
+        }
         delete state.snapshots[id];
         state.snapshotOrder = state.snapshotOrder.filter((i) => i !== id);
       }),
@@ -59,6 +76,20 @@ export const useMetricsSlice = create<MetricsSliceState & MetricsSliceActions>()
       set((state) => {
         state.snapshots = {};
         state.snapshotOrder = [];
+        state.loading = {};
+        state.errors = {};
+      }),
+
+    markLoading: (fileName) =>
+      set((state) => {
+        state.loading[fileName] = true;
+        delete state.errors[fileName];
+      }),
+
+    registerError: (fileName, error) =>
+      set((state) => {
+        state.errors[fileName] = error;
+        delete state.loading[fileName];
       }),
   }))
 );
@@ -106,4 +137,10 @@ export const selectSnapshotSummaries = (state: MetricsSliceState) =>
       seriesCount: computeSeriesCount(snap),
     };
   });
+
+/** Selector for current loading state keyed by file name. */
+export const selectLoading = (state: MetricsSliceState) => state.loading;
+
+/** Selector for recorded errors keyed by file name. */
+export const selectErrors = (state: MetricsSliceState) => state.errors;
 


### PR DESCRIPTION
## Summary
- extend metrics slice with loading & error reducers
- re-enable event listeners in the app bootstrap

## Testing
- `pnpm lint` *(fails: couldn't find eslint config)*
- `pnpm test:unit` *(fails: vitest not found)*
- `pnpm build` *(fails: vite not found)*