### PR TITLE
Clean up global styles

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -4,23 +4,6 @@
 
 @import './design/tokens.css';
 
-:root {
-  /* Typography */
-  --systemFont: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-
-  /* Base colors */
-  --surfaceBg: #1e1e1e;
-  --textPrimary: #e0e0e0;
-
-  /* Visualization colors */
-  --gaugeDefaultColor: #0066CC;
-  --histogramBarColor: #4D9EFC;
-  --histogramHighlightColor: #0066CC;
-  --referenceLineColor: red;
-  --axisLabelColor: #777;
-}
-
 *,
 *::before,
 *::after {
@@ -43,4 +26,13 @@ h6,
 p {
   margin: 0;
   font-weight: inherit;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--headingText);
 }


### PR DESCRIPTION
## Summary
- rely on imported design tokens instead of redefining them in `global.css`
- reference heading text color from tokens

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run test:unit` *(fails: vitest not found)*