### PR TITLE
Add Storybook config and GaugeCard stories

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,17 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.stories.@(ts|tsx)'],
+  addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+  viteFinal: async (config) => {
+    config.plugins = config.plugins || [];
+    config.plugins.push(tsconfigPaths());
+    return config;
+  },
+};
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,4 @@
+import '../src/global.css';
+
+const preview = {};
+export default preview;

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Requires **Node.js >=18.17**. We recommend using
 ```bash
 pnpm i          # install deps
 pnpm dev        # Vite + HMR
+pnpm storybook  # component catalog
 pnpm test:unit  # Jest/Vitest
 pnpm lint
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "storybook": "storybook dev -p 6006",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx,.md",
     "test:unit": "vitest run",
     "test:e2e": "playwright test",
@@ -44,6 +45,9 @@
     "typescript": "^5.1.6",
     "vite": "^6.3.5",
     "vitest": "^3.1.3",
-    "vite-tsconfig-paths": "^4.2.0"
+    "vite-tsconfig-paths": "^4.2.0",
+    "@storybook/react-vite": "^7.6.0",
+    "@storybook/addon-essentials": "^7.6.0",
+    "@storybook/addon-links": "^7.6.0"
   }
 }

--- a/src/ui/atoms/GaugeCard.stories.tsx
+++ b/src/ui/atoms/GaugeCard.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { GaugeCard } from './GaugeCard';
+
+const meta: Meta<typeof GaugeCard> = {
+  title: 'Atoms/GaugeCard',
+  component: GaugeCard,
+};
+export default meta;
+
+type Story = StoryObj<typeof GaugeCard>;
+
+export const Basic: Story = {
+  args: { value: 42, unit: 'ms' },
+};
+
+export const WithColorRanges: Story = {
+  args: {
+    value: 75,
+    unit: 'ms',
+    max: 100,
+    ranges: [
+      { value: 50, color: '#4ade80' },
+      { value: 80, color: '#facc15' },
+      { value: 100, color: '#ef4444' },
+    ],
+  },
+};


### PR DESCRIPTION
## Summary
- add Storybook config using the Vite builder
- define simple GaugeCard stories
- expose `pnpm storybook` script and document usage

## Testing
- `npx vitest run` *(fails: request to https://registry.npmjs.org/vitest failed, reason: connect EHOSTUNREACH)*