### PR TITLE
Add unit tests for file validation, worker dispatch, and key encoding

### DIFF
--- a/tests/dispatchToWorker.test.ts
+++ b/tests/dispatchToWorker.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+class MockWorker {
+  onmessage: ((e: MessageEvent<any>) => void) | null = null;
+  onerror: ((e: any) => void) | null = null;
+  static nextResponse: any;
+  postMessage(data: any) {
+    const resp = { taskId: data.taskId, ...MockWorker.nextResponse };
+    queueMicrotask(() => this.onmessage?.({ data: resp } as any));
+  }
+  terminate() {}
+}
+
+describe('dispatchToParserWorker', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubGlobal('Worker', MockWorker);
+    vi.stubGlobal('navigator', { hardwareConcurrency: 2 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('resolves with worker success payload', async () => {
+    MockWorker.nextResponse = { type: 'parsedSnapshot', payload: { id: 'ok' } };
+    const mod = await import('../src/data/dispatchToWorker');
+    const result = await mod.dispatchToParserWorker({ snapshotId: 's', fileName: 'f.json', rawJson: '{}' });
+    expect(result).toEqual({ type: 'parsedSnapshot', payload: { id: 'ok' } });
+    mod.terminateAllParserWorkers();
+  });
+
+  it('resolves with worker error payload', async () => {
+    MockWorker.nextResponse = { type: 'parserError', payload: { snapshotId: 's', fileName: 'f', message: 'bad' } };
+    const mod = await import('../src/data/dispatchToWorker');
+    const result = await mod.dispatchToParserWorker({ snapshotId: 's', fileName: 'f.json', rawJson: '{}' });
+    expect(result).toEqual(MockWorker.nextResponse);
+    mod.terminateAllParserWorkers();
+  });
+});

--- a/tests/seriesKeyEncoder.test.ts
+++ b/tests/seriesKeyEncoder.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { encodeSeriesKey, decodeSeriesKey, NULL_PLACEHOLDER } from '../src/logic/workers/utils/seriesKeyEncoder';
+
+describe('seriesKeyEncoder', () => {
+  it('round trips encode and decode', () => {
+    const key = encodeSeriesKey(
+      'metric.count',
+      { region: 'us', zone: null },
+      { host: 'srv1', active: true, count: 5 }
+    );
+    const decoded = decodeSeriesKey(key);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.metricName).toBe('metric.count');
+    expect(decoded?.attributes).toEqual({
+      region: 'us',
+      zone: NULL_PLACEHOLDER,
+      host: 'srv1',
+      active: true,
+      count: 5,
+    });
+  });
+});

--- a/tests/validateFile.test.ts
+++ b/tests/validateFile.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { validateFile } from '../src/data/fileValidator';
+
+function makeFile(name: string, size = 0): File {
+  return new File([''], name, { type: 'application/octet-stream', lastModified: 0 });
+}
+
+describe('validateFile', () => {
+  it('accepts supported extensions', () => {
+    const file = makeFile('trace.json');
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('right');
+    if (res.type === 'right') {
+      expect(res.value.file).toBe(file);
+      expect(res.value.isGzipped).toBe(false);
+    }
+  });
+
+  it('flags gzipped files', () => {
+    const file = makeFile('metrics.json.gz');
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('right');
+    if (res.type === 'right') {
+      expect(res.value.isGzipped).toBe(true);
+    }
+  });
+
+  it('rejects invalid extension', () => {
+    const file = makeFile('note.txt');
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('left');
+    if (res.type === 'left') {
+      expect(res.value.code).toBe('INVALID_EXTENSION');
+    }
+  });
+
+  it('rejects when file too large', () => {
+    const file = makeFile('a.json', 200);
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('left');
+    if (res.type === 'left') {
+      expect(res.value.code).toBe('FILE_TOO_LARGE');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for validateFile covering extension checks and size limits
- mock Web Worker to test dispatchToParserWorker
- verify seriesKeyEncoder encode/decode round-trip

## Testing
- `pnpm test:unit` *(fails: Invalid package manager specification)*