### PR TITLE
Refactor formatters into object

### DIFF
--- a/src/ui/atoms/CounterCard.tsx
+++ b/src/ui/atoms/CounterCard.tsx
@@ -10,7 +10,7 @@
  */
 import React from 'react';
 import styles from './CounterCard.module.css';
-import { fmtInt, fmtSI, fmtDeltaAbs } from '@/utils/formatters';
+import { formatters } from '@/utils/formatters';
 
 /**
  * Props for {@link CounterCard}.
@@ -42,7 +42,7 @@ export const CounterCard: React.FC<CounterCardProps> = ({
   className,
 }) => {
   // Format value based on options
-  const formattedValue = useSINotation ? fmtSI(value) : fmtInt(value);
+  const formattedValue = useSINotation ? formatters.SI(value) : formatters.int(value);
 
   return (
     <div className={`${styles.container} ${className || ''}`.trim()}>
@@ -54,7 +54,7 @@ export const CounterCard: React.FC<CounterCardProps> = ({
             delta >= 0 ? styles.positive : styles.negative
           }`}
         >
-          {fmtDeltaAbs(delta)} {delta >= 0 ? '↑' : '↓'}
+          {formatters.deltaAbs(delta)} {delta >= 0 ? '↑' : '↓'}
         </div>
       )}
     </div>

--- a/src/ui/atoms/GaugeCard.tsx
+++ b/src/ui/atoms/GaugeCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import styles from './GaugeCard.module.css';
-import { formatDuration } from '@/utils/formatters';
+import { formatters } from '@/utils/formatters';
 
 /**
  * Radial gauge visualization for gauge metrics and up-down counters.
@@ -50,7 +50,7 @@ export const GaugeCard: React.FC<GaugeCardProps> = ({
   const effectiveMax = max ?? Math.max(value * 1.5, 100);
   const angle = ((value - min) / (effectiveMax - min)) * 180;
   const gaugeColor = determineColor(value, ranges);
-  const formattedValue = unit ? formatDuration(value, unit) : value.toString();
+  const formattedValue = unit ? formatters.duration(value, unit) : value.toString();
 
   return (
     <div className={`${styles.container} ${className ?? ''}`.trim()}>

--- a/src/ui/organisms/ExemplarsZone.tsx
+++ b/src/ui/organisms/ExemplarsZone.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { ExemplarData } from '@/contracts/types';
-import { formatTimestamp, formatDuration } from '@/utils/formatters';
+import { formatters } from '@/utils/formatters';
 import { CopyButton } from '@/ui/atoms/CopyButton';
 import styles from './ExemplarsZone.module.css';
 
@@ -80,7 +80,7 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
                   className={`${styles.dot} ${isSelected ? styles.selected : ''}`}
                   style={{ left: `${position}%` }}
                   onClick={() => handleExemplarSelect(exemplar)}
-                  title={`Value: ${exemplar.value}, Time: ${formatTimestamp(exemplar.timeUnixNano)}`}
+                  title={`Value: ${exemplar.value}, Time: ${formatters.timestamp(exemplar.timeUnixNano)}`}
                 />
               );
             })}
@@ -96,7 +96,7 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
                   style={{ left: `${position}%` }}
                 >
                   <span className={styles.tickLabel}>
-                    {formatTimestamp(timeRange.minTime + (timeRange.span * (position / 100)))}
+                    {formatters.timestamp(timeRange.minTime + (timeRange.span * (position / 100)))}
                   </span>
                 </div>
               ))}
@@ -109,10 +109,10 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
         <div className={styles.details}>
           <div className={styles.header}>
             <div className={styles.timestamp}>
-              {formatTimestamp(selectedExemplar.timeUnixNano, true)}
+              {formatters.timestamp(selectedExemplar.timeUnixNano, true)}
             </div>
             <div className={styles.value}>
-              value: {formatDuration(selectedExemplar.value)}
+              value: {formatters.duration(selectedExemplar.value)}
             </div>
           </div>
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,33 +1,36 @@
 /**
- * Format a number with thousand separators.
+ * Collection of formatting helpers used across UI components.
  */
-export function fmtInt(value: number): string {
-  return value.toLocaleString();
-}
+export const formatters = {
+  /** Format a number with thousand separators. */
+  int(value: number): string {
+    return value.toLocaleString();
+  },
 
-/**
- * Format a number with SI unit suffix (K, M, G, etc).
- */
-export function fmtSI(value: number): string {
-  if (value < 1000) return value.toString();
-  if (value < 1000000) return `${(value / 1000).toFixed(1)}K`;
-  if (value < 1000000000) return `${(value / 1000000).toFixed(1)}M`;
-  return `${(value / 1000000000).toFixed(1)}G`;
-}
+  /** Format a number with SI unit suffix (K, M, G, etc). */
+  SI(value: number): string {
+    if (value < 1000) return value.toString();
+    if (value < 1000000) return `${(value / 1000).toFixed(1)}K`;
+    if (value < 1000000000) return `${(value / 1000000).toFixed(1)}M`;
+    return `${(value / 1000000000).toFixed(1)}G`;
+  },
 
-/**
- * Format a delta value (change) with a + or - sign.
- */
-export function fmtDeltaAbs(value: number): string {
-  return Math.abs(value).toLocaleString();
-}
+  /** Format a delta value (change) with a + or - sign. */
+  deltaAbs(value: number): string {
+    return Math.abs(value).toLocaleString();
+  },
 
-/**
- * Format a duration value in appropriate units.
- */
-export function formatDuration(value: number, unit: string): string {
-  if (unit === 'ms' && value > 1000) {
-    return `${(value / 1000).toFixed(2)}s`;
-  }
-  return `${value}${unit}`;
-}
+  /** Format a duration value in appropriate units. */
+  duration(value: number, unit: string): string {
+    if (unit === 'ms' && value > 1000) {
+      return `${(value / 1000).toFixed(2)}s`;
+    }
+    return `${value}${unit}`;
+  },
+
+  /** Format a Unix nanosecond timestamp. */
+  timestamp(value: number, withDate = false): string {
+    const date = new Date(value / 1_000_000);
+    return withDate ? date.toLocaleString() : date.toLocaleTimeString();
+  },
+};


### PR DESCRIPTION
## Summary
- reorganize `formatters` as an object with helpers
- update CounterCard, GaugeCard and ExemplarsZone to use the new API

## Testing
- `npm install` *(fails: no output)*