### PR TITLE
Update CLAUDE development commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ IntelliMetric Explorer / Data-Point Inspector Drawer is a specialized UI compone
 - Raw JSON access with copy functionality
 
 ## Development Commands
+Requires Node.js 18.17 or later. All examples use `pnpm`.
 
 ```bash
 # Install dependencies


### PR DESCRIPTION
## Summary
- clarify that Node 18.17+ is required and pnpm is used for commands

## Testing
- `pnpm lint` *(fails: Parsing error because dependencies missing)*
- `pnpm i` *(fails: EHOSTUNREACH registry.npmjs.org)*