### PR TITLE
Enable global event listener registration

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
-import { registerEventListeners } from '@/services/eventListeners';
+import { registerGlobalEventListeners } from '@/services/eventListeners';
 import App from './App';
 import './global.css';
 
@@ -22,5 +22,5 @@ root.render(
   </React.StrictMode>
 );
 
-registerEventListeners();
+registerGlobalEventListeners();
 

--- a/src/services/eventListeners.ts
+++ b/src/services/eventListeners.ts
@@ -25,7 +25,7 @@ import type { EventTypes } from './eventTypes';
  * Call once during application startup. Returns a function that
  * unregisters all handlers when invoked.
  */
-export function registerEventListeners(): () => void {
+export function registerGlobalEventListeners(): () => void {
   const metricsActions = useMetricsSlice.getState();
   const uiActions = useUiSlice.getState();
 
@@ -65,3 +65,6 @@ export function registerEventListeners(): () => void {
     eventBus.off('*');
   };
 }
+
+export { registerGlobalEventListeners as registerEventListeners };
+export default registerGlobalEventListeners;

--- a/tests/eventListeners.test.ts
+++ b/tests/eventListeners.test.ts
@@ -1,0 +1,55 @@
+import { describe, beforeEach, afterEach, it, expect } from 'vitest';
+import { bus } from '../src/services/eventBus';
+import { registerGlobalEventListeners } from '../src/services/eventListeners';
+import { useMetricsSlice } from '../src/state/metricsSlice';
+import useUiSlice from '../src/state/uiSlice';
+import type { ParsedSnapshot } from '../src/contracts/types';
+
+let cleanup: () => void;
+
+function makeSnapshot(id: string, fileName: string): ParsedSnapshot {
+  return { id, fileName, ingestionTimestamp: 0, resources: [] } as ParsedSnapshot;
+}
+
+describe('registerGlobalEventListeners', () => {
+  beforeEach(() => {
+    useMetricsSlice.getState().clearSnapshots();
+    useUiSlice.getState().resetUi();
+    cleanup = registerGlobalEventListeners();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('handles data events', () => {
+    bus.emit('data.snapshot.load.start', { fileName: 'a.json' });
+    expect(useMetricsSlice.getState().loading['a.json']).toBe(true);
+
+    bus.emit('data.snapshot.error', { fileName: 'a.json', error: 'err' });
+    let state = useMetricsSlice.getState();
+    expect(state.errors['a.json']).toBe('err');
+    expect(state.loading['a.json']).toBeUndefined();
+
+    const snap = makeSnapshot('id1', 'a.json');
+    bus.emit('data.snapshot.parsed', { snapshot: snap });
+    state = useMetricsSlice.getState();
+    expect(state.snapshots['id1']).toEqual(snap);
+    expect(state.errors['a.json']).toBeUndefined();
+    expect(state.loading['a.json']).toBeUndefined();
+  });
+
+  it('handles ui events', () => {
+    bus.emit('ui.inspector.open', { snapshotId: 's1', metricName: 'm1', seriesKey: 'm1|', pointId: 2 });
+    let ui = useUiSlice.getState();
+    expect(ui.activeSnapshotId).toBe('s1');
+    expect(ui.inspectedMetricName).toBe('m1');
+    expect(ui.inspectedSeriesKey).toBe('m1|');
+    expect(ui.inspectedPointId).toBe(2);
+    expect(ui.isInspectorOpen).toBe(true);
+
+    bus.emit('ui.inspector.close');
+    ui = useUiSlice.getState();
+    expect(ui.isInspectorOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `registerGlobalEventListeners` in services
- hook global event listeners in application entry
- cover listener behaviour with unit tests

## Testing
- `pnpm exec vitest run` *(fails: Command "vitest" not found)*