### PR TITLE
Add timestamp formatter

### DIFF
--- a/src/ui/organisms/ExemplarsZone.tsx
+++ b/src/ui/organisms/ExemplarsZone.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useMemo } from 'react';
 import { ExemplarData } from '@/contracts/types';
-import { formatters } from '@/utils/formatters';
+import { formatters, formatTimestamp } from '@/utils/formatters';
 import { CopyButton } from '@/ui/atoms/CopyButton';
 import styles from './ExemplarsZone.module.css';
 
@@ -80,7 +80,7 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
                   className={`${styles.dot} ${isSelected ? styles.selected : ''}`}
                   style={{ left: `${position}%` }}
                   onClick={() => handleExemplarSelect(exemplar)}
-                  title={`Value: ${exemplar.value}, Time: ${formatters.timestamp(exemplar.timeUnixNano)}`}
+                  title={`Value: ${exemplar.value}, Time: ${formatTimestamp(exemplar.timeUnixNano)}`}
                 />
               );
             })}
@@ -96,7 +96,7 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
                   style={{ left: `${position}%` }}
                 >
                   <span className={styles.tickLabel}>
-                    {formatters.timestamp(timeRange.minTime + (timeRange.span * (position / 100)))}
+                    {formatTimestamp(timeRange.minTime + (timeRange.span * (position / 100)))}
                   </span>
                 </div>
               ))}
@@ -109,10 +109,10 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
         <div className={styles.details}>
           <div className={styles.header}>
             <div className={styles.timestamp}>
-              {formatters.timestamp(selectedExemplar.timeUnixNano, true)}
+              {formatTimestamp(selectedExemplar.timeUnixNano, true)}
             </div>
             <div className={styles.value}>
-              value: {formatters.duration(selectedExemplar.value)}
+              value: {formatters.int(selectedExemplar.value)}
             </div>
           </div>
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,6 +1,17 @@
 /**
  * Collection of formatting helpers used across UI components.
  */
+/**
+ * Format a Unix nanosecond timestamp into a locale string.
+ *
+ * @param ns - Timestamp in nanoseconds
+ * @param long - Include the date portion when true
+ */
+export function formatTimestamp(ns: number, long = false): string {
+  const date = new Date(Math.floor(ns / 1_000_000));
+  return long ? date.toLocaleString() : date.toLocaleTimeString();
+}
+
 export const formatters = {
   /** Format a number with thousand separators. */
   int(value: number): string {
@@ -30,7 +41,6 @@ export const formatters = {
 
   /** Format a Unix nanosecond timestamp. */
   timestamp(value: number, withDate = false): string {
-    const date = new Date(value / 1_000_000);
-    return withDate ? date.toLocaleString() : date.toLocaleTimeString();
+    return formatTimestamp(value, withDate);
   },
 };


### PR DESCRIPTION
## Summary
- implement `formatTimestamp` helper
- use `formatTimestamp` in ExemplarsZone
- show exemplar values with `formatters.int`

## Testing
- `pnpm lint` *(fails: node_modules missing)*
- `pnpm i` *(fails: EHOSTUNREACH for npm registry)*