### PR TITLE
Add tests for data utilities

### DIFF
--- a/tests/decompressGzip.test.ts
+++ b/tests/decompressGzip.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { gzip } from 'pako';
+import { decompressGzip } from '../src/data/decompressGzip';
+
+describe('decompressGzip', () => {
+  it('inflates a known sample', async () => {
+    const text = 'hello world';
+    const gz = gzip(text);
+    const buffer = gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength);
+    const result = await decompressGzip(buffer);
+    expect(result).toBe(text);
+  });
+
+  it('throws on corrupt buffer', async () => {
+    const buf = new Uint8Array([1, 2, 3]).buffer;
+    await expect(decompressGzip(buf)).rejects.toThrow('Gzip decompression failed.');
+  });
+
+  it('does not modify the input buffer', async () => {
+    const text = 'ok';
+    const gz = gzip(text);
+    const buffer = gz.buffer.slice(gz.byteOffset, gz.byteOffset + gz.byteLength);
+    const copy = buffer.slice(0);
+    await decompressGzip(buffer);
+    expect(new Uint8Array(buffer)).toEqual(new Uint8Array(copy));
+  });
+});

--- a/tests/fileValidator.test.ts
+++ b/tests/fileValidator.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { validateFile } from '../src/data/fileValidator';
+
+function makeFile(name: string, size = 0): File {
+  return new File(['content'], name, { type: 'application/octet-stream', lastModified: 0, });
+}
+
+describe('fileValidator', () => {
+  it('accepts supported extensions', () => {
+    const file = makeFile('trace.json');
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('right');
+    if (res.type === 'right') {
+      expect(res.value.file).toBe(file);
+      expect(res.value.isGzipped).toBe(false);
+    }
+  });
+
+  it('flags gzipped files', () => {
+    const file = makeFile('metrics.json.gz');
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('right');
+    if (res.type === 'right') {
+      expect(res.value.isGzipped).toBe(true);
+    }
+  });
+
+  it('rejects invalid extension', () => {
+    const file = makeFile('note.txt');
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('left');
+    if (res.type === 'left') {
+      expect(res.value.code).toBe('INVALID_EXTENSION');
+    }
+  });
+
+  it('rejects when file too large', () => {
+    const file = makeFile('a.json', 200);
+    const res = validateFile(file, 100);
+    expect(res.type).toBe('left');
+    if (res.type === 'left') {
+      expect(res.value.code).toBe('FILE_TOO_LARGE');
+    }
+  });
+});

--- a/tests/readFile.test.ts
+++ b/tests/readFile.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileContent } from '../src/data/readFile';
+import type { ValidFile } from '../src/data/fileValidator';
+import { decompressGzip } from '../src/data/decompressGzip';
+
+vi.mock('../src/data/decompressGzip', () => ({
+  decompressGzip: vi.fn(),
+}));
+
+const decompressMock = decompressGzip as unknown as ReturnType<typeof vi.fn>;
+
+class MockFileReader {
+  static nextBuffer: ArrayBuffer = new ArrayBuffer(0);
+  static fail = false;
+
+  result: ArrayBuffer | null = null;
+  error: DOMException | null = null;
+  onload: ((ev: any) => void) | null = null;
+  onerror: ((ev: any) => void) | null = null;
+
+  readAsArrayBuffer(_file: File) {
+    if (MockFileReader.fail) {
+      this.error = new DOMException('read fail');
+      queueMicrotask(() => this.onerror?.(new Event('error')));
+    } else {
+      this.result = MockFileReader.nextBuffer;
+      queueMicrotask(() => this.onload?.(new Event('load')));
+    }
+  }
+}
+
+function makeValidFile(name: string, isGz: boolean): ValidFile {
+  const file = new File(['dummy'], name);
+  return { file, isGzipped: isGz };
+}
+
+describe('readFileContent', () => {
+  beforeEach(() => {
+    vi.stubGlobal('FileReader', MockFileReader as any);
+    decompressMock.mockReset();
+    MockFileReader.fail = false;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('reads plain text files', async () => {
+    const text = 'plain';
+    MockFileReader.nextBuffer = new TextEncoder().encode(text).buffer;
+    const vf = makeValidFile('a.json', false);
+    const result = await readFileContent(vf);
+    expect(result).toBe(text);
+    expect(decompressMock).not.toHaveBeenCalled();
+  });
+
+  it('inflates gzipped files', async () => {
+    const buffer = new ArrayBuffer(8);
+    MockFileReader.nextBuffer = buffer;
+    decompressMock.mockResolvedValue('unzipped');
+    const vf = makeValidFile('b.json.gz', true);
+    const result = await readFileContent(vf);
+    expect(result).toBe('unzipped');
+    expect(decompressMock).toHaveBeenCalledWith(buffer);
+  });
+
+  it('rejects on read error', async () => {
+    MockFileReader.fail = true;
+    const vf = makeValidFile('c.json', false);
+    await expect(readFileContent(vf)).rejects.toThrow('File read error');
+  });
+
+  it('rejects when decompression fails', async () => {
+    const buffer = new ArrayBuffer(1);
+    MockFileReader.nextBuffer = buffer;
+    decompressMock.mockRejectedValue(new Error('boom'));
+    const vf = makeValidFile('d.json.gz', true);
+    await expect(readFileContent(vf)).rejects.toThrow('boom');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests covering fileValidator
- test gzip decompression utility
- test readFileContent helper with mocked FileReader

## Testing
- `pnpm test:unit` *(fails: vitest not found)*