### PR TITLE
Add layer restrictions via ESLint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,2 @@
+const fs = require('fs');
+module.exports = JSON.parse(fs.readFileSync(__dirname + '/.eslintrc.json', 'utf8'));

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,63 @@
+{
+  "root": true,
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "rules": {
+    "semi": ["error", "always"]
+  },
+  "overrides": [
+    {
+      "files": ["src/contracts/**/*"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@/*"] }]
+      }
+    },
+    {
+      "files": ["src/data/**/*"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          { "patterns": ["@/state/**", "@/ui/**", "@/logic/processing/**", "@/logic/workers/**", "@/hooks/**", "@/services/**"] }
+        ]
+      }
+    },
+    {
+      "files": ["src/logic/workers/**/*"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@/state/**", "@/ui/**"] }]
+      }
+    },
+    {
+      "files": ["src/logic/processing/**/*"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@/ui/**", "@/data/**", "@/logic/workers/!(utils)/**", "@/services/**"] }]
+      }
+    },
+    {
+      "files": ["src/state/**/*"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@/ui/**"] }]
+      }
+    },
+    {
+      "files": ["src/hooks/**/*"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@/data/**", "@/logic/workers/**"] }]
+      }
+    },
+    {
+      "files": ["src/ui/**/*"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@/data/**", "@/logic/workers/**", "@/logic/processing/**"] }]
+      }
+    },
+    {
+      "files": ["src/services/**/*"],
+      "rules": {
+        "no-restricted-imports": ["error", { "patterns": ["@/ui/**"] }]
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
-    "lint": "eslint . --ext .ts,.tsx,.js,.jsx,.md",
+    "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.cjs . --ext .ts,.tsx,.js,.jsx,.md",
     "test:unit": "vitest run",
     "test:perf": "node scripts/perf-budget.js",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary
- add `.eslintrc.json` describing cross-layer import restrictions
- expose legacy config through `.eslintrc.cjs`
- update `lint` script to use the new config

## Testing
- `pnpm lint` *(fails: parsing errors)*