### PR TITLE
Fix drop simulation reduction percent

### DIFF
--- a/src/contracts/types.ts
+++ b/src/contracts/types.ts
@@ -144,6 +144,8 @@ export interface ParsedSnapshot {
 export interface MetricCardinalityContext {
   /** Total number of unique series. */
   seriesCount: SeriesCount;
+  /** Series count before any drop simulation. */
+  baseSeriesCount: SeriesCount;
   /** Map of attribute keys to their unique value counts. */
   attrUniq: Record<string, UniqueCount>;
   /** Attribute keys ranked by unique count descending. */
@@ -179,6 +181,8 @@ export interface InspectorProps {
   cardinality: {
     /** Total series count for the metric. */
     seriesCount: SeriesCount;
+    /** Original series count before simulation. */
+    baseSeriesCount: SeriesCount;
     /** Unique attribute value counts. */
     attrUniq: Record<string, UniqueCount>;
     /** Attribute keys ranked by unique count. */

--- a/src/logic/metricProcessor.ts
+++ b/src/logic/metricProcessor.ts
@@ -103,6 +103,7 @@ export function getProcessedMetricInfo(
     definition: metric.definition,
     cardinality: {
       seriesCount,
+      baseSeriesCount: baseCount,
       attrUniq: stats.attrUniq,
       attrRank: stats.attrRank,
     },

--- a/src/ui/organisms/CardinalityCapsule.tsx
+++ b/src/ui/organisms/CardinalityCapsule.tsx
@@ -20,6 +20,8 @@ import { InstrumentBadge } from '@/ui/atoms/InstrumentBadge';
 export interface CardinalityCapsuleProps {
   /** Current series count for the metric. */
   seriesCount: number;
+  /** Series count before any drop simulation. */
+  baseSeriesCount: number;
   /** Threshold where cardinality is considered high. */
   thresholdHigh: number;
   /** Ordered list of attribute keys by impact on cardinality. */
@@ -48,6 +50,7 @@ export interface CardinalityCapsuleProps {
  */
 export const CardinalityCapsule: React.FC<CardinalityCapsuleProps> = ({
   seriesCount,
+  baseSeriesCount,
   thresholdHigh,
   attrRank,
   attrUniq,
@@ -77,10 +80,8 @@ export const CardinalityCapsule: React.FC<CardinalityCapsuleProps> = ({
 
   // Calculate reduction percentage when simulation is active
   const reductionPct =
-    isDropSimActive && droppedKey && attrUniq[droppedKey]
-      ? Math.round(
-          (1 - seriesCount / (seriesCount * attrUniq[droppedKey])) * 100,
-        )
+    isDropSimActive && droppedKey && baseSeriesCount
+      ? Math.round((1 - seriesCount / baseSeriesCount) * 100)
       : 0;
 
   return (

--- a/src/ui/organisms/DataPointInspectorDrawer.tsx
+++ b/src/ui/organisms/DataPointInspectorDrawer.tsx
@@ -134,6 +134,7 @@ export const DataPointInspectorDrawer: React.FC<DataPointInspectorDrawerProps> =
 
         <CardinalityCapsule
           seriesCount={cardinality.seriesCount}
+          baseSeriesCount={cardinality.baseSeriesCount}
           thresholdHigh={cardinality.thresholdHigh}
           attrRank={cardinality.attrRank}
           attrUniq={cardinality.attrUniq}

--- a/tests/CardinalityCapsule.test.tsx
+++ b/tests/CardinalityCapsule.test.tsx
@@ -9,6 +9,7 @@ describe('CardinalityCapsule', () => {
     render(
       <CardinalityCapsule
         seriesCount={10}
+        baseSeriesCount={10}
         thresholdHigh={100}
         attrRank={['method']}
         attrUniq={{ method: 1 }}
@@ -26,6 +27,26 @@ describe('CardinalityCapsule', () => {
     onFocusAttr.mockClear();
     fireEvent.keyDown(row, { key: ' ' });
     expect(onFocusAttr).toHaveBeenCalledWith('method');
+  });
+
+  it('shows correct reduction percentage when drop simulation active', () => {
+    render(
+      <CardinalityCapsule
+        seriesCount={60}
+        baseSeriesCount={100}
+        thresholdHigh={100}
+        attrRank={['method']}
+        attrUniq={{ method: 2 }}
+        focusedAttrKey="method"
+        onFocusAttr={vi.fn()}
+        onToggleDrop={vi.fn()}
+        isDropSimActive={true}
+        droppedKey="method"
+      />
+    );
+    expect(
+      screen.getByText(/\u2192 60 series \(40% less\)/)
+    ).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## Summary
- compute percent change using base series count
- surface baseSeriesCount through MetricCardinalityContext
- show projected reduction correctly in CardinalityCapsule
- update DataPointInspectorDrawer and tests for new prop

## Testing
- `pnpm test:unit` *(fails: vitest not found)*