### PR TITLE
Add unit tests for data and processing logic

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,16 @@ application.
 - **ValueZone.test.tsx** – covers rendering logic for values and histograms in
   the `ValueZone` component.
 - **uiSlice.test.ts** – exercises the UI state slice helpers and selectors.
+- **validateFile.test.ts** – checks extension and size validation logic.
+- **decompressGzip.test.ts** – ensures gzipped buffers inflate correctly and errors propagate.
+- **readFile.test.ts** – reads plain and gzipped files via mocked `FileReader`.
+- **jsonSafeParse.test.ts** – handles valid and malformed JSON safely.
+- **exemplarExtractor.test.ts** – maps raw OTLP exemplars to internal form.
+- **attributeStats.test.ts** – computes unique attribute counts and ranking.
+- **jaccardEstimator.test.ts** – branch coverage for similarity maths.
+- **seriesCardinalityCalc.test.ts** – projects series counts when attributes drop.
+- **uniqueValueCounter.test.ts** – tracks unique primitive values.
+- **seriesKeyEncoder.test.ts** – encodes and decodes stable series identifiers.
 
 ## Running Tests
 

--- a/tests/attributeStats.test.ts
+++ b/tests/attributeStats.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { calculateAttributeStatsForMetric } from '../src/logic/processing/attributeStats';
+import type { ParsedMetricData, ParsedSeriesData } from '../src/contracts/types';
+
+function makeSeries(key: string, res: Record<string,string>, met: Record<string,string>): ParsedSeriesData {
+  return { seriesKey: key, resourceAttributes: res, metricAttributes: met, points: [] };
+}
+
+function makeMetric(series: ParsedSeriesData[]): ParsedMetricData {
+  const map = new Map(series.map(s => [s.seriesKey, s]));
+  return { definition: { name: 'm', instrumentType: 'Gauge' }, seriesData: map };
+}
+
+describe('calculateAttributeStatsForMetric', () => {
+  it('computes unique counts and rank', () => {
+    const metric = makeMetric([
+      makeSeries('s1', { 'host.name': 'a' }, { 'http.method': 'GET', 'k8s.pod': 'p1' }),
+      makeSeries('s2', { 'host.name': 'a' }, { 'http.method': 'POST', 'k8s.pod': 'p2' }),
+      makeSeries('s3', { 'host.name': 'a' }, { 'http.method': 'GET', 'k8s.pod': 'p3' }),
+    ]);
+    const stats = calculateAttributeStatsForMetric(metric);
+    expect(stats.attrUniq['host.name']).toBe(1);
+    expect(stats.attrUniq['http.method']).toBe(2);
+    expect(stats.attrUniq['k8s.pod']).toBe(3);
+    expect(stats.attrRank).toEqual(['k8s.pod', 'http.method', 'host.name']);
+  });
+
+  it('handles empty metric', () => {
+    const metric = makeMetric([]);
+    const stats = calculateAttributeStatsForMetric(metric);
+    expect(stats.attrUniq).toEqual({});
+    expect(stats.attrRank).toEqual([]);
+  });
+});

--- a/tests/decompressGzip.test.ts
+++ b/tests/decompressGzip.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { decompressGzip } from '../src/data/decompressGzip';
+
+vi.mock('pako', () => ({ inflate: vi.fn() }));
+import { inflate } from 'pako';
+
+const textBuffer = new TextEncoder().encode('hello').buffer;
+
+describe('decompressGzip', () => {
+  it('returns inflated string', async () => {
+    (inflate as unknown as vi.Mock).mockReturnValue('result');
+    const res = await decompressGzip(textBuffer);
+    expect(res).toBe('result');
+    expect(inflate).toHaveBeenCalledWith(new Uint8Array(textBuffer), { to: 'string' });
+  });
+
+  it('throws on error', async () => {
+    (inflate as unknown as vi.Mock).mockImplementation(() => { throw new Error('err'); });
+    await expect(decompressGzip(textBuffer)).rejects.toThrow('Gzip decompression failed.');
+  });
+});

--- a/tests/exemplarExtractor.test.ts
+++ b/tests/exemplarExtractor.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { extractExemplars } from '../src/logic/workers/utils/exemplarExtractor';
+import type { RawOtlpExemplar } from '../src/contracts/rawOtlpTypes';
+
+describe('extractExemplars', () => {
+  it('returns empty array for undefined', () => {
+    expect(extractExemplars(undefined)).toEqual([]);
+  });
+
+  it('maps exemplar fields and attributes', () => {
+    const raw: RawOtlpExemplar[] = [
+      {
+        timeUnixNano: '1',
+        asDouble: 2.5,
+        spanId: 's',
+        traceId: 't',
+        filteredAttributes: [
+          { key: 'a', value: { stringValue: 'v' } },
+          { key: 'b', value: { intValue: '5' } },
+          { key: 'c', value: { doubleValue: 1.2 } },
+          { key: 'd', value: { boolValue: true } },
+          { key: 'skip', value: { kvlistValue: [] as any } },
+        ],
+      },
+    ];
+    const ex = extractExemplars(raw);
+    expect(ex).toEqual([
+      {
+        timeUnixNano: 1,
+        value: 2.5,
+        spanId: 's',
+        traceId: 't',
+        attributes: { a: 'v', b: 5, c: 1.2, d: true },
+      },
+    ]);
+  });
+});

--- a/tests/jaccardEstimator.test.ts
+++ b/tests/jaccardEstimator.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { estimateJaccard } from '../src/logic/processing/jaccardEstimator';
+
+describe('estimateJaccard', () => {
+  it('returns 1 for two empty sets', () => {
+    expect(estimateJaccard({}, {})).toBe(1);
+  });
+
+  it('returns 1 for identical maps', () => {
+    expect(estimateJaccard({ a: 1, b: 2 }, { a: 1, b: 2 })).toBe(1);
+  });
+
+  it('returns 0 for disjoint sets', () => {
+    expect(estimateJaccard({ a: 1 }, { b: 2 })).toBe(0);
+  });
+
+  it('computes partial overlap', () => {
+    expect(estimateJaccard({ a: 1, b: 2 }, { a: 1, b: 3 })).toBeCloseTo(0.5);
+  });
+});

--- a/tests/jsonSafeParse.test.ts
+++ b/tests/jsonSafeParse.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { jsonSafeParse } from '../src/logic/workers/utils/jsonSafeParse';
+
+describe('jsonSafeParse', () => {
+  it('parses valid JSON', () => {
+    const res = jsonSafeParse('{"a":1}');
+    expect(res).toEqual({ type: 'right', value: { a: 1 } });
+  });
+
+  it('returns error for invalid JSON', () => {
+    const res = jsonSafeParse('{oops');
+    expect(res.type).toBe('left');
+    if (res.type === 'left') {
+      expect(res.value).toBeInstanceOf(Error);
+    }
+  });
+});

--- a/tests/readFile.test.ts
+++ b/tests/readFile.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { ValidFile } from '../src/data/fileValidator';
+
+class MockFileReader {
+  static buffer: ArrayBuffer | null = null;
+  static shouldError = false;
+  onload: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  readAsArrayBuffer(_file: File) {
+    if (MockFileReader.shouldError) {
+      queueMicrotask(() => this.onerror?.());
+    } else {
+      queueMicrotask(() => {
+        (this as any).result = MockFileReader.buffer;
+        this.onload?.();
+      });
+    }
+  }
+}
+
+describe('readFileContent', () => {
+  const file = new File(['dummy'], 'a.json');
+  const gzFile = new File(['gz'], 'b.json.gz');
+
+  beforeEach(() => {
+    (global as any).FileReader = MockFileReader;
+    MockFileReader.buffer = new TextEncoder().encode('text').buffer;
+    MockFileReader.shouldError = false;
+  });
+
+  it('reads plain text files', async () => {
+    const vf: ValidFile = { file, isGzipped: false };
+    const { readFileContent } = await import('../src/data/readFile');
+    const text = await readFileContent(vf);
+    expect(text).toBe('text');
+  });
+
+  it('reads gzipped files via decompress', async () => {
+    const vf: ValidFile = { file: gzFile, isGzipped: true };
+    vi.mock('../src/data/decompressGzip', () => ({ decompressGzip: vi.fn().mockResolvedValue('unzipped') }));
+    const { readFileContent } = await import("../src/data/readFile");
+    const text = await readFileContent(vf);
+    expect(text).toBe('unzipped');
+  });
+
+  it('propagates read errors', async () => {
+    MockFileReader.shouldError = true;
+    const vf: ValidFile = { file, isGzipped: false };
+    const { readFileContent } = await import("../src/data/readFile");
+    await expect(readFileContent(vf)).rejects.toThrow('File read error');
+  });
+});

--- a/tests/seriesCardinalityCalc.test.ts
+++ b/tests/seriesCardinalityCalc.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { getActualSeriesCount, simulateDroppedAttributesSeriesCount } from '../src/logic/processing/seriesCardinalityCalc';
+import type { ParsedMetricData, ParsedSeriesData } from '../src/contracts/types';
+
+function makeSeries(key: string, res: Record<string,string>, met: Record<string,string>): ParsedSeriesData {
+  return { seriesKey: key, resourceAttributes: res, metricAttributes: met, points: [] };
+}
+
+function makeMetric(series: ParsedSeriesData[]): ParsedMetricData {
+  const map = new Map(series.map(s => [s.seriesKey, s]));
+  return { definition: { name: 'metric', instrumentType: 'Gauge' }, seriesData: map };
+}
+
+describe('series cardinality calc', () => {
+  const metric = makeMetric([
+    makeSeries('k1', { host: 'a' }, { status: '200' }),
+    makeSeries('k2', { host: 'b' }, { status: '500' }),
+  ]);
+
+  it('gets actual series count', () => {
+    expect(getActualSeriesCount(metric)).toBe(2);
+  });
+
+  it('no keys dropped equals actual', () => {
+    expect(simulateDroppedAttributesSeriesCount(metric, [])).toBe(2);
+  });
+
+  it('dropping unique attr collapses count', () => {
+    expect(simulateDroppedAttributesSeriesCount(metric, ['host','status'])).toBe(1);
+  });
+
+  it('dropping missing attr leaves count', () => {
+    expect(simulateDroppedAttributesSeriesCount(metric, ['none'])).toBe(2);
+  });
+});

--- a/tests/seriesKeyEncoder.test.ts
+++ b/tests/seriesKeyEncoder.test.ts
@@ -19,4 +19,9 @@ describe('seriesKeyEncoder', () => {
       count: 5,
     });
   });
+
+  it('decode returns null on malformed key', () => {
+    expect(decodeSeriesKey('')).toBeNull();
+    expect(decodeSeriesKey('metric|a')).toBeNull();
+  });
 });

--- a/tests/uniqueValueCounter.test.ts
+++ b/tests/uniqueValueCounter.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { getUniqueValues, countUniqueValues } from '../src/logic/processing/utils/uniqueValueCounter';
+
+describe('uniqueValueCounter', () => {
+  it('counts and collects unique primitives', () => {
+    const values = ['a', 'b', 'a', 1, 1, true, false];
+    const set = getUniqueValues(values);
+    expect(Array.from(set)).toEqual(['a', 'b', 1, true, false]);
+    expect(countUniqueValues(values)).toBe(5);
+  });
+
+  it('treats numbers and strings separately', () => {
+    const values = ['42', 42];
+    expect(countUniqueValues(values)).toBe(2);
+  });
+
+  it('handles empty iterable', () => {
+    expect(countUniqueValues([])).toBe(0);
+    expect(Array.from(getUniqueValues([]))).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for modules in `src/data`, worker utils and processing logic
- extend series key decoder tests
- document new tests in `tests/README.md`

## Testing
- `pnpm i` *(fails: EHOSTUNREACH)*