### PR TITLE
Refactor large UI organisms into hooks

### DIFF
--- a/src/ui/organisms/DataPointInspectorDrawer.tsx
+++ b/src/ui/organisms/DataPointInspectorDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import React, { useMemo, useRef } from 'react';
 import type { InspectorProps } from '@/contracts/types';
 import { InspectorHeader } from './InspectorHeader';
 import { ValueZone } from './ValueZone';
@@ -7,6 +7,7 @@ import { AttributeZone } from './AttributeZone';
 import { ExemplarsZone } from './ExemplarsZone';
 import { RawJsonZone } from './RawJsonZone';
 import { useFocusTrap } from '@/hooks/useFocusTrap';
+import { useDrawerInteractions } from './useDrawerInteractions';
 import styles from './DataPointInspectorDrawer.module.css';
 
 /**
@@ -56,30 +57,13 @@ export const DataPointInspectorDrawer: React.FC<DataPointInspectorDrawerProps> =
   className,
   positionRight = true,
 }) => {
-  const [focusedAttrKey, setFocusedAttrKey] = useState<string | null>(null);
-  const [droppedKey, setDroppedKey] = useState<string | null>(null);
   const drawerRef = useRef<HTMLDivElement>(null);
-
-  const handleToggleDrop = useCallback(
-    (attrKey: string, nextState: boolean) => {
-      if (onSimulateDrop) {
-        onSimulateDrop(attrKey, nextState);
-      }
-      setDroppedKey(nextState ? attrKey : null);
-    },
-    [onSimulateDrop]
-  );
-
-  // Close on ESC key
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [onClose]);
+  const {
+    focusedAttrKey,
+    setFocusedAttrKey,
+    droppedKey,
+    handleToggleDrop
+  } = useDrawerInteractions(onClose, onSimulateDrop);
 
   // Trap focus inside drawer while mounted
   useFocusTrap(drawerRef);

--- a/src/ui/organisms/ExemplarsZone.tsx
+++ b/src/ui/organisms/ExemplarsZone.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useMemo } from 'react';
+import React from 'react';
 import { ExemplarData } from '@/contracts/types';
 import { formatters } from '@/utils/formatters';
 import { CopyButton } from '@/ui/atoms/CopyButton';
 import styles from './ExemplarsZone.module.css';
+import { useExemplarTimeline } from './useExemplarTimeline';
 
 /**
  * Timeline visualization of exemplars associated with a data point.
@@ -37,31 +38,13 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
   exemplars,
   onExemplarClick
 }) => {
-  const [selectedExemplar, setSelectedExemplar] = useState<ExemplarData | null>(null);
-
-  const sortedExemplars = useMemo(() => {
-    return [...exemplars].sort((a, b) => a.timeUnixNano - b.timeUnixNano);
-  }, [exemplars]);
-
-  const timeRange = useMemo(() => {
-    if (sortedExemplars.length < 2) return null;
-
-    const minTime = sortedExemplars[0].timeUnixNano;
-    const maxTime = sortedExemplars[sortedExemplars.length - 1].timeUnixNano;
-    return { minTime, maxTime, span: maxTime - minTime };
-  }, [sortedExemplars]);
-
-  const handleExemplarSelect = (exemplar: ExemplarData) => {
-    setSelectedExemplar(exemplar);
-    if (onExemplarClick) {
-      onExemplarClick(exemplar);
-    }
-  };
-
-  const getPositionPercent = (timestamp: number) => {
-    if (!timeRange || timeRange.span === 0) return 0;
-    return ((timestamp - timeRange.minTime) / timeRange.span) * 100;
-  };
+  const {
+    selectedExemplar,
+    sortedExemplars,
+    timeRange,
+    handleSelect,
+    getPositionPercent
+  } = useExemplarTimeline(exemplars, onExemplarClick);
 
   return (
     <div className={styles.container}>
@@ -79,7 +62,7 @@ export const ExemplarsZone: React.FC<ExemplarsZoneProps> = ({
                   key={`${exemplar.timeUnixNano}-${index}`}
                   className={`${styles.dot} ${isSelected ? styles.selected : ''}`}
                   style={{ left: `${position}%` }}
-                  onClick={() => handleExemplarSelect(exemplar)}
+                  onClick={() => handleSelect(exemplar)}
                   title={`Value: ${exemplar.value}, Time: ${formatters.timestamp(exemplar.timeUnixNano)}`}
                 />
               );

--- a/src/ui/organisms/RawJsonZone.tsx
+++ b/src/ui/organisms/RawJsonZone.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React from 'react';
 import { CopyButton } from '@/ui/atoms/CopyButton';
 import type { ParsedPoint, AttrMap } from '@/contracts/types';
 import styles from './RawJsonZone.module.css';
+import { useRawJson } from './useRawJson';
 
 /**
  * Collapsible JSON view of raw metric data with copy capabilities.
@@ -55,59 +56,20 @@ export const RawJsonZone: React.FC<RawJsonZoneProps> = ({
   metricAttrs,
   initialCollapsed = true,
 }) => {
-  const [isCollapsed, setIsCollapsed] = useState(initialCollapsed);
-  const [showFullContext, setShowFullContext] = useState(false);
-
-  const toggleCollapse = useCallback(() => {
-    setIsCollapsed((prev) => !prev);
-  }, []);
-
-  const toggleFullContext = useCallback(() => {
-    setShowFullContext((prev) => !prev);
-  }, []);
-
-  const pointJson = useMemo(() => {
-    const data = {
-      metricName,
-      point: {
-        ...point,
-        attributes: { ...metricAttrs },
-      },
-    };
-    return JSON.stringify(data, null, 2);
-  }, [metricName, point, metricAttrs]);
-
-  const fullJson = useMemo(() => {
-    const data = {
-      resource: { attributes: { ...resourceAttrs } },
-      scopeMetrics: [
-        {
-          scope: { name: 'unknown.scope', attributes: {} },
-          metrics: [
-            {
-              name: metricName,
-              type: (point as any).bucketCounts ? 'HISTOGRAM' : 'GAUGE',
-              dataPoints: [
-                {
-                  ...point,
-                  attributes: { ...metricAttrs },
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    };
-    return JSON.stringify(data, null, 2);
-  }, [metricName, point, resourceAttrs, metricAttrs]);
-
-  const displayJson = showFullContext ? fullJson : pointJson;
-
-  const handleCopy = useCallback(() => {
-    return displayJson;
-  }, [displayJson]);
-
-  const getCopyValue = useCallback(() => handleCopy(), [handleCopy]);
+  const {
+    isCollapsed,
+    toggleCollapse,
+    showFullContext,
+    toggleFullContext,
+    displayJson,
+    getCopyValue,
+  } = useRawJson(
+    metricName,
+    point,
+    resourceAttrs,
+    metricAttrs,
+    initialCollapsed
+  );
 
   if (isCollapsed) {
     return (

--- a/src/ui/organisms/useCloseOnEsc.ts
+++ b/src/ui/organisms/useCloseOnEsc.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+export function useCloseOnEsc(onClose: () => void) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => {
+      document.removeEventListener('keydown', handler);
+    };
+  }, [onClose]);
+}

--- a/src/ui/organisms/useDrawerInteractions.ts
+++ b/src/ui/organisms/useDrawerInteractions.ts
@@ -1,0 +1,30 @@
+import { useState, useCallback } from 'react';
+
+import { useCloseOnEsc } from './useCloseOnEsc';
+
+export function useDrawerInteractions(
+  onClose: () => void,
+  onSimulateDrop?: (key: string, drop: boolean) => void
+) {
+  const [focusedAttrKey, setFocusedAttrKey] = useState<string | null>(null);
+  const [droppedKey, setDroppedKey] = useState<string | null>(null);
+
+  const handleToggleDrop = useCallback(
+    (attrKey: string, nextState: boolean) => {
+      if (onSimulateDrop) {
+        onSimulateDrop(attrKey, nextState);
+      }
+      setDroppedKey(nextState ? attrKey : null);
+    },
+    [onSimulateDrop]
+  );
+
+  useCloseOnEsc(onClose);
+
+  return {
+    focusedAttrKey,
+    setFocusedAttrKey,
+    droppedKey,
+    handleToggleDrop
+  };
+}

--- a/src/ui/organisms/useExemplarTimeline.ts
+++ b/src/ui/organisms/useExemplarTimeline.ts
@@ -1,0 +1,47 @@
+import { useState, useMemo, useCallback } from 'react';
+import { ExemplarData } from '@/contracts/types';
+
+export function useExemplarTimeline(
+  exemplars: ExemplarData[],
+  onExemplarClick?: (exemplar: ExemplarData) => void
+) {
+  const [selectedExemplar, setSelectedExemplar] = useState<ExemplarData | null>(
+    null
+  );
+
+  const sortedExemplars = useMemo(
+    () => [...exemplars].sort((a, b) => a.timeUnixNano - b.timeUnixNano),
+    [exemplars]
+  );
+
+  const timeRange = useMemo(() => {
+    if (sortedExemplars.length < 2) return null;
+    const minTime = sortedExemplars[0].timeUnixNano;
+    const maxTime = sortedExemplars[sortedExemplars.length - 1].timeUnixNano;
+    return { minTime, maxTime, span: maxTime - minTime };
+  }, [sortedExemplars]);
+
+  const handleSelect = useCallback(
+    (exemplar: ExemplarData) => {
+      setSelectedExemplar(exemplar);
+      onExemplarClick?.(exemplar);
+    },
+    [onExemplarClick]
+  );
+
+  const getPositionPercent = useCallback(
+    (timestamp: number) => {
+      if (!timeRange || timeRange.span === 0) return 0;
+      return ((timestamp - timeRange.minTime) / timeRange.span) * 100;
+    },
+    [timeRange]
+  );
+
+  return {
+    selectedExemplar,
+    sortedExemplars,
+    timeRange,
+    handleSelect,
+    getPositionPercent
+  };
+}

--- a/src/ui/organisms/useRawJson.ts
+++ b/src/ui/organisms/useRawJson.ts
@@ -1,0 +1,69 @@
+import { useState, useCallback, useMemo } from 'react';
+import type { ParsedPoint, AttrMap } from '@/contracts/types';
+
+export function useRawJson(
+  metricName: string,
+  point: ParsedPoint,
+  resourceAttrs: AttrMap,
+  metricAttrs: AttrMap,
+  initialCollapsed = true
+) {
+  const [isCollapsed, setIsCollapsed] = useState(initialCollapsed);
+  const [showFullContext, setShowFullContext] = useState(false);
+
+  const toggleCollapse = useCallback(() => {
+    setIsCollapsed(prev => !prev);
+  }, []);
+
+  const toggleFullContext = useCallback(() => {
+    setShowFullContext(prev => !prev);
+  }, []);
+
+  const pointJson = useMemo(() => {
+    const data = {
+      metricName,
+      point: {
+        ...point,
+        attributes: { ...metricAttrs }
+      }
+    };
+    return JSON.stringify(data, null, 2);
+  }, [metricName, point, metricAttrs]);
+
+  const fullJson = useMemo(() => {
+    const data = {
+      resource: { attributes: { ...resourceAttrs } },
+      scopeMetrics: [
+        {
+          scope: { name: 'unknown.scope', attributes: {} },
+          metrics: [
+            {
+              name: metricName,
+              type: (point as any).bucketCounts ? 'HISTOGRAM' : 'GAUGE',
+              dataPoints: [
+                {
+                  ...point,
+                  attributes: { ...metricAttrs }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    };
+    return JSON.stringify(data, null, 2);
+  }, [metricName, point, resourceAttrs, metricAttrs]);
+
+  const displayJson = showFullContext ? fullJson : pointJson;
+
+  const getCopyValue = useCallback(() => displayJson, [displayJson]);
+
+  return {
+    isCollapsed,
+    toggleCollapse,
+    showFullContext,
+    toggleFullContext,
+    displayJson,
+    getCopyValue
+  };
+}


### PR DESCRIPTION
## Summary
- extract `useRawJson` from `RawJsonZone`
- use `useDrawerInteractions` and `useCloseOnEsc` inside `DataPointInspectorDrawer`
- move exemplar timeline logic into `useExemplarTimeline`
- update imports across organisms

## Testing
- `pnpm lint` *(fails: Parsing error)*
- `pnpm test:unit` *(fails: vitest not found)*