### PR TITLE
Update code comment header docs

### DIFF
--- a/src/02-Code-Comment-Guide.md
+++ b/src/02-Code-Comment-Guide.md
@@ -3,15 +3,38 @@
 
 ---
 
-## Required Tags
+## Required File Header
 
-| Tag | Description |
-|-----|-------------|
-| `@purpose` | Briefly states why the module or function exists. |
-| `@algorithm` | Lists key steps of non-trivial logic in bullet or numbered form. |
-| `@perfBudget` | **Deprecated.** Historical tag for stating local performance targets. Budgets now live in [Architecture Principles](01-Architecture-Principles.md#6-performance-budgets). |
+Every TypeScript module begins with the same structured TSDoc block. The header
+contains the following tags in order:
 
-`@perfBudget` may still appear in legacy files but should not be added to new code.
+- `@file` – A short title for the module.
+- `@summary` – One sentence summarising the module's role.
+- `@remarks` – Expanded documentation with two subsections:
+  - **Purpose** – Why the module exists and how it fits in.
+  - **Public API** – What the module exports and any usage notes.
+- `@layer` – The architecture layer name from
+  [Architecture Principles](01-Architecture-Principles.md#1-layer-model).
+
+The historical `@perfBudget` tag is deprecated. Performance budgets now live in
+[Architecture Principles](01-Architecture-Principles.md#6-performance-budgets)
+and should not be added to new files, though it may appear in legacy headers.
+
+### Example Header
+
+```ts
+/**
+ * @file StaticFileProvider.tsx
+ * @summary Browser UI for loading snapshot files.
+ * @remarks
+ * ### Purpose
+ * Provides a drag-and-drop area to load local snapshots and send them to the parser worker.
+ * ### Public API
+ * - `StaticFileProvider` React component
+ * - `StaticFileProviderProps` interface
+ * @layer Data Provider
+ */
+```
 
 ## Good Comment Example
 


### PR DESCRIPTION
## Summary
- document new file header tag requirements
- note that `@perfBudget` is deprecated
- show example header block

## Testing
- `pnpm lint` *(fails: parsing errors and missing node modules)*
- `pnpm test:unit` *(fails: vitest not found)*
