### PR TITLE
Fix leftover merge markers in AttributeZone.module.css

### DIFF
--- a/src/ui/organisms/AttributeZone.module.css
+++ b/src/ui/organisms/AttributeZone.module.css
@@ -4,11 +4,7 @@
   gap: 8px;
 }
 
-<<<<<<< HEAD
-.grid {
-=======
 .list {
->>>>>>> origin/codex/refactor-attributerow-import-and-usage
   display: flex;
   flex-direction: column;
   gap: 4px;


### PR DESCRIPTION
## Summary
- resolve merge conflict markers in `AttributeZone.module.css`
- keep `.list` class for attributes list style

## Testing
- `npm run lint` *(fails: Parsing error)*
- `npm run test:unit` *(fails: vitest not found)*