### PR TITLE
Update path alias

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,11 @@
     "moduleResolution": "Node",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": "./src",
+    "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"],
-      "@intellimetric/contracts": ["../packages/contracts"],
-      "@intellimetric/contracts/*": ["../packages/contracts/*"]
+      "@/*": ["src/*"],
+      "@intellimetric/contracts": ["packages/contracts"],
+      "@intellimetric/contracts/*": ["packages/contracts/*"]
     },
     "types": ["node"]
   },

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,17 +1,12 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
-import path from 'path';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.js'],
     globals: true,
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
   },
 });


### PR DESCRIPTION
## Summary
- set base URL to project root in tsconfig
- update Vitest config to use vite-tsconfig-paths

## Testing
- `pnpm test:unit` *(fails: vitest not found)*
- `pnpm exec tsc --noEmit` *(fails: cannot find type definition file for 'node')*