### PR TITLE
Add data-testid attributes for metric cards

### DIFF
--- a/src/ui/atoms/CounterCard.tsx
+++ b/src/ui/atoms/CounterCard.tsx
@@ -45,7 +45,7 @@ export const CounterCard: React.FC<CounterCardProps> = ({
   const formattedValue = useSINotation ? formatters.SI(value) : formatters.int(value);
 
   return (
-    <div className={`${styles.container} ${className || ''}`.trim()}>
+    <div data-testid="counter-card" className={`${styles.container} ${className || ''}`.trim()}>
       <div className={styles.value}>{formattedValue}</div>
       {unit && <div className={styles.unit}>{unit}</div>}
       {delta !== undefined && (

--- a/src/ui/atoms/GaugeCard.tsx
+++ b/src/ui/atoms/GaugeCard.tsx
@@ -53,7 +53,7 @@ export const GaugeCard: React.FC<GaugeCardProps> = ({
   const formattedValue = unit ? formatters.duration(value, unit) : value.toString();
 
   return (
-    <div className={`${styles.container} ${className ?? ''}`.trim()}>
+    <div data-testid="gauge-card" className={`${styles.container} ${className ?? ''}`.trim()}>
       <div className={styles.gauge}>
         <svg viewBox="0 0 100 50" className={styles.gaugeSvg}>
           <path

--- a/src/ui/atoms/HistogramMiniChart.tsx
+++ b/src/ui/atoms/HistogramMiniChart.tsx
@@ -86,6 +86,7 @@ export const HistogramMiniChart: React.FC<HistogramMiniChartProps> = ({
 
   return (
     <div
+      data-testid="histogram-chart"
       className={className}
       style={{ display: 'flex', flexDirection: 'column', width: '100%', height: height + 40 }}
     >


### PR DESCRIPTION
## Summary
- add `data-testid` attributes to `GaugeCard`, `CounterCard` and `HistogramMiniChart`

## Testing
- `pnpm test:unit` *(fails: vitest not found; node modules missing)*