### PR TITLE
Remove perf test script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,4 @@ jobs:
 
       - run: pnpm lint
       - run: pnpm test:unit -- --ci
-      - run: pnpm test:perf
       - run: pnpm build

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "storybook": "storybook dev -p 6006",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.cjs . --ext .ts,.tsx,.js,.jsx,.md",
     "test:unit": "vitest run",
-    "test:perf": "node scripts/perf-budget.js",
     "test:e2e": "playwright test",
     "build:storybook": "storybook build",
     "docs:mkdocs": "mkdocs build",


### PR DESCRIPTION
## Summary
- delete `test:perf` from `package.json`
- remove the unused perf test step from the CI workflow

## Testing
- `pnpm lint` *(fails: node_modules missing)*
- `pnpm test:unit` *(fails: vitest not found)*