### PR TITLE
Add Playwright e2e setup

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,4 +13,5 @@ jobs:
         with: { version: 8 }
       - run: pnpm i --frozen-lockfile
       - run: pnpm build
+      - run: npx playwright install --with-deps
       - run: pnpm test:e2e

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests/e2e',
+  webServer: {
+    command: 'pnpm preview --port 5173',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+});

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,3 +39,15 @@ Vitest runs in a JSDOM environment. Coverage reports can be generated with:
 pnpm test:unit -- --coverage
 ```
 
+## End-to-End Tests
+
+E2E tests use [Playwright](https://playwright.dev/) and run against a local
+preview server. Build the app and execute the tests with:
+
+```bash
+pnpm build
+pnpm test:e2e
+```
+
+The workflow `.github/workflows/e2e.yml` runs these tests nightly on CI.
+

--- a/tests/e2e/dataPointInspector.spec.ts
+++ b/tests/e2e/dataPointInspector.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const fixturePath = path.resolve(__dirname, '../fixtures/basic-snapshot.json');
+
+test('DataPointInspector drawer zones visible', async ({ page }) => {
+  await page.goto('/');
+
+  await page.setInputFiles('input[type="file"]', fixturePath);
+
+  const drawer = page.getByRole('dialog');
+  await expect(drawer).toBeVisible();
+
+  await expect(drawer.getByRole('heading')).toBeVisible();
+  await expect(drawer.getByText(/series/i)).toBeVisible();
+  await expect(drawer.getByText('ATTRIBUTES')).toBeVisible();
+  await expect(drawer.getByText('EXEMPLARS')).toBeVisible();
+  await expect(drawer.getByText('RAW DATA')).toBeVisible();
+});

--- a/tests/fixtures/basic-snapshot.json
+++ b/tests/fixtures/basic-snapshot.json
@@ -1,0 +1,47 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          { "key": "service.name", "value": { "stringValue": "demo" } }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {
+            "name": "test",
+            "version": "1.0.0"
+          },
+          "metrics": [
+            {
+              "name": "cpu_temp",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      { "key": "host", "value": { "stringValue": "server1" } },
+                      { "key": "cpu", "value": { "stringValue": "1" } }
+                    ],
+                    "timeUnixNano": "1",
+                    "asDouble": 42.5,
+                    "exemplars": [
+                      {
+                        "timeUnixNano": "2",
+                        "asDouble": 42.5,
+                        "spanId": "abcd",
+                        "traceId": "efgh",
+                        "filteredAttributes": [
+                          { "key": "trace", "value": { "stringValue": "example" } }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Playwright with a preview server
- add a basic e2e spec and fixture
- install browsers in the e2e workflow
- document running e2e tests

## Testing
- `pnpm test:unit` *(fails: vitest not found)*
- `pnpm test:e2e` *(fails: playwright not found)*