### PR TITLE
Add canonical header for formatters

### DIFF
--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,5 +1,10 @@
 /**
- * Collection of formatting helpers used across UI components.
+ * Helper functions for formatting numbers, durations and timestamps.
+ *
+ * The module exports {@link formatTimestamp} and a {@link formatters} object
+ * with convenience methods consumed by UI components.
+ *
+ * @packageDocumentation
  */
 /**
  * Format a Unix nanosecond timestamp into a locale string.


### PR DESCRIPTION
## Summary
- add a canonical header to `src/utils/formatters.ts`

## Testing
- `pnpm lint` *(fails: node_modules missing)*
- `pnpm test:unit` *(fails: vitest not found)*
