### PR TITLE
Add typecheck script and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - run: pnpm i --frozen-lockfile
 
       - run: pnpm lint
+      - run: pnpm typecheck
       - run: pnpm test:unit -- --ci
       - run: pnpm test:perf
       - run: pnpm build

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ pnpm i          # install deps
 pnpm dev        # Vite + HMR
 pnpm storybook  # component catalog
 pnpm test:unit  # Jest/Vitest
+pnpm typecheck  # TypeScript compile check
 pnpm lint
 pnpm generate:tokens  # update design-tokens.ts from tokens.css
 ```

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint -c .eslintrc.cjs . --ext .ts,.tsx,.js,.jsx,.md",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:unit": "vitest run",
     "test:perf": "node scripts/perf-budget.js",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary
- add `typecheck` npm script
- run type checking during CI
- document `pnpm typecheck` in README

## Testing
- `pnpm typecheck` *(fails: Cannot find type definition file for 'node')*
- `pnpm lint` *(fails to parse test files)*
- `pnpm test:unit -- --ci` *(fails: vitest not found)*