### PR TITLE
Add console log capture to Playwright tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,5 +9,8 @@ export default defineConfig({
   },
   use: {
     baseURL: 'http://localhost:5173',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
   },
 });

--- a/tests/e2e/dataPointInspector.spec.ts
+++ b/tests/e2e/dataPointInspector.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures';
 import path from 'path';
 
 const fixturePath = path.resolve(__dirname, '../fixtures/basic-snapshot.json');

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -1,0 +1,20 @@
+import { test as base, expect } from '@playwright/test';
+import fs from 'fs';
+
+export const test = base.extend<{ page: import('@playwright/test').Page }>({
+  page: async ({ page }, use, testInfo) => {
+    const logs: string[] = [];
+    page.on('console', msg => {
+      logs.push(`[${msg.type()}] ${msg.text()}`);
+    });
+    await use(page);
+    if (logs.length) {
+      const file = testInfo.outputPath('console.log');
+      await fs.promises.mkdir(testInfo.outputDir, { recursive: true });
+      await fs.promises.writeFile(file, logs.join('\n'), 'utf8');
+      await testInfo.attach('console', { path: file, contentType: 'text/plain' });
+    }
+  },
+});
+
+export { expect };


### PR DESCRIPTION
## Summary
- update Playwright defaults for screenshots, trace and video
- log browser console output per test

## Testing
- `pnpm i` *(fails: EHOSTUNREACH)*