### PR TITLE
Add artifact upload for failed E2E runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,3 +15,11 @@ jobs:
       - run: pnpm build
       - run: npx playwright install --with-deps
       - run: pnpm test:e2e
+      - name: Upload e2e artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report
+          path: |
+            playwright-report
+            test-results


### PR DESCRIPTION
## Summary
- upload Playwright report and test results when E2E tests fail

## Testing
- `pnpm lint` *(fails: cannot find dependencies)*