### PR TITLE
Add e2e tests for drawer interactions

### DIFF
--- a/tests/e2e/drawerInteractions.spec.ts
+++ b/tests/e2e/drawerInteractions.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const fixturePath = path.resolve(__dirname, '../fixtures/basic-snapshot.json');
+
+test('drawer attribute focus, drop simulation and close', async ({ page }) => {
+  await page.goto('/');
+  await page.setInputFiles('input[type="file"]', fixturePath);
+
+  const drawer = page.getByRole('dialog');
+  await expect(drawer).toBeVisible();
+
+  // focus first attribute
+  await drawer.getByText('host').click();
+  await expect(drawer.getByText('Simulate drop: host')).toBeVisible();
+
+  // toggle drop simulation
+  const checkbox = drawer.getByRole('checkbox');
+  await checkbox.check();
+  await expect(drawer.getByText(/series/)).toBeVisible();
+
+  // close via ESC
+  await page.keyboard.press('Escape');
+  await expect(drawer).not.toBeVisible();
+});

--- a/tests/e2e/rawJsonCopy.spec.ts
+++ b/tests/e2e/rawJsonCopy.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+const fixturePath = path.resolve(__dirname, '../fixtures/basic-snapshot.json');
+
+test('raw json expand/collapse and copy', async ({ page }) => {
+  await page.goto('/');
+  await page.setInputFiles('input[type="file"]', fixturePath);
+
+  const drawer = page.getByRole('dialog');
+  await expect(drawer).toBeVisible();
+
+  const expandBtn = drawer.getByRole('button', { name: 'Expand raw data' });
+  await expandBtn.click();
+  await expect(drawer.getByRole('button', { name: /Collapse raw data/ })).toBeVisible();
+
+  await page.evaluate(() => {
+    window.__copied = '';
+    navigator.clipboard.writeText = (text: string) => {
+      (window as any).__copied = text;
+      return Promise.resolve();
+    };
+  });
+
+  await drawer.getByRole('button', { name: 'Copy JSON' }).click();
+  const copied = await page.evaluate(() => (window as any).__copied);
+  expect(copied).toContain('"metricName"');
+
+  await drawer.getByRole('button', { name: 'Collapse raw data' }).click();
+  await expect(drawer.getByRole('button', { name: 'Expand raw data' })).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add drawer interactions test covering focus, drop simulation and ESC close
- add raw JSON view test verifying expand/collapse and copy functionality

## Testing
- `pnpm test:e2e` *(fails: playwright not found)*