### PR TITLE
Refactor parser modules

### DIFF
--- a/src/data/dispatchToWorker.ts
+++ b/src/data/dispatchToWorker.ts
@@ -1,106 +1,35 @@
-/**
- * Create and manage a micro‑pool of Web Workers running `parser.worker.ts` and expose a promise-based API.
- *
- * @purpose Orchestrate parallel parsing of OTLP data across worker threads with progress tracking.
- * @algorithm
- * 1. Maintain a singleton pool of workers and dispatch tasks in round-robin fashion.
- * 2. Track progress for each task and emit progress events at regular intervals.
- * 3. Support task cancellation to abort parsing operations.
- * 4. Provide synchronous fallback when workers are not supported.
- * 
- * Dependencies: browser `Worker`, `crypto.randomUUID`, `parser.worker.ts` bundle path.
- * Consumers: StaticFileProvider and future bulk-import features.
- * Tests: mocked Worker to validate success, failure, round-robin, and termination.
- */
-
-import type { ParsedSnapshot } from '@intellimetric/contracts/types';
 import { jsonSafeParse } from '@/logic/workers/utils/jsonSafeParse';
 import { mapToParsedSnapshot } from '@/logic/workers/mapping/otlpMapper';
 import type { RawOtlpExportMetricsServiceRequest } from '@intellimetric/contracts/rawOtlpTypes';
 import { bus } from '@/services/eventBus';
 import { randomId } from '@/utils/randomId';
+import {
+  ensurePool,
+  emitProgress,
+  nextWorker,
+  workerSupported,
+  inFlight,
+} from './workerPool';
+import {
+  isTaskCanceled,
+  cancelParserTask,
+  terminateAllParserWorkers,
+} from './parserCancellation';
+import type { ParseTask, WorkerSuccess, WorkerFailure } from './parserTypes';
 
-export interface ParseTask {
-  snapshotId: string;
-  fileName: string;
-  rawJson: string;
-  fileSize: number;
-}
-
-export interface ParserErrorPayload {
-  snapshotId: string;
-  fileName: string;
-  taskId: string;
-  message: string;
-  detail?: string;
-}
-
-export interface ProgressPayload {
-  taskId: string;
-  fileName: string;
-  progress: number;
-  stage: 'parsing' | 'mapping' | 'processing';
-}
-
-export type WorkerSuccess = {
-  type: 'parsedSnapshot';
-  payload: ParsedSnapshot;
-  taskId: string;
-};
-
-export type WorkerFailure = {
-  type: 'parserError';
-  payload: ParserErrorPayload;
-};
-
-export type WorkerProgress = {
-  type: 'parserProgress';
-  payload: ProgressPayload;
-};
-
-const workerSupported = (() => {
-  try {
-    return (
-      typeof Worker !== 'undefined' &&
-      typeof URL !== 'undefined' &&
-      typeof import.meta.url === 'string'
-    );
-  } catch {
-    return false;
-  }
-})();
-
-const workers: Worker[] = [];
-const inFlight = new Map<
-  string,
-  {
-    resolve: (r: WorkerSuccess | WorkerFailure) => void;
-    reject: (reason: any) => void;
-    worker: Worker;
-    task: ParseTask;
-    canceled: boolean;
-    progressInterval?: number;
-  }
->();
-let rr = 0;
-let poolSize = 0;
-
-// List of taskIds that have been canceled but not yet completed
-const canceledTasks = new Set<string>();
-
-async function parseSynchronously(taskId: string, task: ParseTask): Promise<WorkerSuccess | WorkerFailure> {
-  // Emit initial progress
+async function parseSynchronously(
+  taskId: string,
+  task: ParseTask,
+): Promise<WorkerSuccess | WorkerFailure> {
   emitProgress(taskId, task.fileName, 0, 'parsing');
-  
-  // Check for cancellation
-  if (canceledTasks.has(taskId)) {
+
+  if (isTaskCanceled(taskId)) {
     throw new Error('Task canceled');
   }
-  
-  // Parse JSON (about 33% of the work)
+
   const parsed = jsonSafeParse<RawOtlpExportMetricsServiceRequest>(task.rawJson);
   emitProgress(taskId, task.fileName, 33, 'parsing');
-  
+
   if (parsed.type === 'left') {
     return {
       type: 'parserError',
@@ -114,33 +43,28 @@ async function parseSynchronously(taskId: string, task: ParseTask): Promise<Work
     };
   }
 
-  // Check for cancellation again
-  if (canceledTasks.has(taskId)) {
+  if (isTaskCanceled(taskId)) {
     throw new Error('Task canceled');
   }
-  
+
   emitProgress(taskId, task.fileName, 50, 'mapping');
-  
+
   try {
-    // Map to internal structure (another 33%)
-    const snapshot = mapToParsedSnapshot(parsed.value, task.snapshotId, task.fileName);
-    
-    // Final processing and validation (remaining 34%)
+    const snapshot = mapToParsedSnapshot(
+      parsed.value,
+      task.snapshotId,
+      task.fileName,
+    );
+
     emitProgress(taskId, task.fileName, 90, 'processing');
-    
-    // Check for cancellation one last time
-    if (canceledTasks.has(taskId)) {
+
+    if (isTaskCanceled(taskId)) {
       throw new Error('Task canceled');
     }
-    
-    // Complete
+
     emitProgress(taskId, task.fileName, 100, 'processing');
-    
-    return { 
-      type: 'parsedSnapshot', 
-      payload: snapshot,
-      taskId
-    };
+
+    return { type: 'parsedSnapshot', payload: snapshot, taskId };
   } catch (err: any) {
     const error = err instanceof Error ? err : new Error(String(err));
     return {
@@ -156,192 +80,40 @@ async function parseSynchronously(taskId: string, task: ParseTask): Promise<Work
   }
 }
 
-function emitProgress(taskId: string, fileName: string, progress: number, stage: ProgressPayload['stage']) {
-  // Don't emit progress for canceled tasks
-  if (canceledTasks.has(taskId)) return;
-  
-  const progressEvent: WorkerProgress = {
-    type: 'parserProgress',
-    payload: {
-      taskId,
-      fileName,
-      progress,
-      stage
-    }
-  };
-  
-  // Emit to event bus
-  bus.emit('data.snapshot.load.progress', progressEvent.payload);
-}
-
-function ensurePool() {
-  if (!workerSupported) return;
-  if (workers.length) return;
-  const cores = typeof navigator !== 'undefined' && navigator.hardwareConcurrency ? navigator.hardwareConcurrency : 2;
-  poolSize = Math.min(4, Math.max(1, cores - 1));
-  for (let i = 0; i < poolSize; i += 1) {
-    const worker = new Worker(new URL('../logic/workers/parser.worker.ts', import.meta.url), { type: 'module' });
-    worker.onmessage = (e: MessageEvent<any>) => {
-      const { taskId, type, ...data } = e.data;
-      const entry = inFlight.get(taskId);
-      
-      if (!entry) return; // Task may have been canceled
-      
-      // Handle progress updates
-      if (type === 'progress') {
-        const progressData = data as ProgressPayload;
-        emitProgress(taskId, progressData.fileName, progressData.progress, progressData.stage);
-        return;
-      }
-      
-      // Clear the progress interval if it exists
-      if (entry.progressInterval) {
-        clearInterval(entry.progressInterval);
-      }
-      
-      // Handle task completion
-      if (!entry.canceled) {
-        entry.resolve({ ...data, taskId });
-      }
-      
-      inFlight.delete(taskId);
-      canceledTasks.delete(taskId);
-    };
-    
-    worker.onerror = (err) => {
-      console.error('Worker crash', err);
-      for (const [taskId, entry] of Array.from(inFlight.entries())) {
-        if (entry.worker === worker) {
-          // Clear the progress interval if it exists
-          if (entry.progressInterval) {
-            clearInterval(entry.progressInterval);
-          }
-          
-          // Only resolve if the task hasn't been canceled
-          if (!entry.canceled) {
-            entry.resolve({
-              type: 'parserError',
-              payload: {
-                snapshotId: entry.task.snapshotId,
-                fileName: entry.task.fileName,
-                taskId,
-                message: 'Worker crashed',
-                detail: err?.message || 'Unknown worker error',
-              },
-            });
-          }
-          
-          inFlight.delete(taskId);
-          canceledTasks.delete(taskId);
-        }
-      }
-    };
-    
-    workers.push(worker);
-  }
-}
-
-/**
- * Dispatch parsing work to the next available worker with progress tracking.
- *
- * @param task - Snapshot parsing task.
- * @returns Promise resolving with the worker result or parser error.
- * @throws Error if the task is canceled before completion.
- */
-export function dispatchToParserWorker(task: ParseTask): Promise<WorkerSuccess | WorkerFailure> {
+export function dispatchToParserWorker(
+  task: ParseTask,
+): Promise<WorkerSuccess | WorkerFailure> {
   const taskId = randomId();
-  
-  // Report initial load event
-  bus.emit('data.snapshot.load.start', { fileName: task.fileName, fileSize: task.fileSize });
-  
+  bus.emit('data.snapshot.load.start', {
+    fileName: task.fileName,
+    fileSize: task.fileSize,
+  });
+
   if (!workerSupported) {
     return parseSynchronously(taskId, task);
   }
-  
+
   ensurePool();
-  
+
   return new Promise((resolve, reject) => {
-    const worker = workers[rr];
-    const entry = { 
-      resolve, 
-      reject, 
-      worker, 
-      task, 
+    const worker = nextWorker();
+    const entry = {
+      resolve,
+      reject,
+      worker,
+      task,
       canceled: false,
-    };
-    
-    // Setup periodic progress pings for large files
-    if (task.fileSize > 5 * 1024 * 1024) { // 5MB+ gets progress updates
+    } as any;
+
+    if (task.fileSize > 5 * 1024 * 1024) {
       entry.progressInterval = setInterval(() => {
         worker.postMessage({ taskId, type: 'pingProgress' });
       }, 500) as unknown as number;
     }
-    
+
     inFlight.set(taskId, entry);
     worker.postMessage({ taskId, type: 'parse', payload: task });
-    rr = (rr + 1) % poolSize;
   });
 }
 
-/**
- * Cancel a parsing task that is in progress.
- * 
- * @param taskId - The ID of the task to cancel.
- * @returns True if the task was found and canceled, false otherwise.
- */
-export function cancelParserTask(taskId: string): boolean {
-  const entry = inFlight.get(taskId);
-  
-  if (!entry) return false;
-  
-  canceledTasks.add(taskId);
-  entry.canceled = true;
-  
-  // Clear progress interval if it exists
-  if (entry.progressInterval) {
-    clearInterval(entry.progressInterval);
-    entry.progressInterval = undefined;
-  }
-  
-  // Notify worker to stop processing (it may ignore this if already done)
-  entry.worker.postMessage({ taskId, type: 'cancel' });
-  
-  // Emit cancellation event
-  bus.emit('data.snapshot.load.cancel', { 
-    fileName: entry.task.fileName, 
-    taskId 
-  });
-  
-  // Reject the promise
-  entry.reject(new Error('Task canceled'));
-  
-  // Keep the entry in inFlight until the worker acknowledges cancellation
-  return true;
-}
-
-/**
- * Terminate all active parser workers and clear state.
- *
- * @remarks
- * Used during application teardown or hot reloads.
- */
-export function terminateAllParserWorkers(): void {
-  if (!workerSupported) return;
-  
-  // Cancel all in-flight tasks
-  for (const [taskId, entry] of inFlight.entries()) {
-    if (entry.progressInterval) {
-      clearInterval(entry.progressInterval);
-    }
-    entry.canceled = true;
-    entry.reject(new Error('Worker terminated'));
-  }
-  
-  // Terminate all workers
-  workers.forEach((w) => w.terminate());
-  workers.length = 0;
-  
-  // Clear state
-  inFlight.clear();
-  canceledTasks.clear();
-}
+export { cancelParserTask, terminateAllParserWorkers };

--- a/src/data/parserCancellation.ts
+++ b/src/data/parserCancellation.ts
@@ -1,0 +1,58 @@
+import { bus } from '@/services/eventBus';
+import { inFlight, workers, workerSupported } from './workerPool';
+import type { ParseTask } from './parserTypes';
+
+const canceledTasks = new Set<string>();
+
+export function isTaskCanceled(taskId: string): boolean {
+  return canceledTasks.has(taskId);
+}
+
+export function removeCanceledTask(taskId: string): void {
+  canceledTasks.delete(taskId);
+}
+
+function markTaskCanceled(taskId: string): void {
+  canceledTasks.add(taskId);
+}
+
+export function cancelParserTask(taskId: string): boolean {
+  const entry = inFlight.get(taskId);
+  if (!entry) return false;
+
+  markTaskCanceled(taskId);
+  entry.canceled = true;
+
+  if (entry.progressInterval) {
+    clearInterval(entry.progressInterval);
+    entry.progressInterval = undefined;
+  }
+
+  entry.worker.postMessage({ taskId, type: 'cancel' });
+
+  bus.emit('data.snapshot.load.cancel', {
+    fileName: entry.task.fileName,
+    taskId,
+  });
+
+  entry.reject(new Error('Task canceled'));
+  return true;
+}
+
+export function terminateAllParserWorkers(): void {
+  if (!workerSupported) return;
+
+  for (const [taskId, entry] of inFlight.entries()) {
+    if (entry.progressInterval) {
+      clearInterval(entry.progressInterval);
+    }
+    entry.canceled = true;
+    entry.reject(new Error('Worker terminated'));
+  }
+
+  workers.forEach((w) => w.terminate());
+  workers.length = 0;
+
+  inFlight.clear();
+  canceledTasks.clear();
+}

--- a/src/data/parserTypes.ts
+++ b/src/data/parserTypes.ts
@@ -1,0 +1,51 @@
+/**
+ * Data structures exchanged between the main thread and parser workers.
+ *
+ * These types are imported by worker pool and cancellation helpers as well as
+ * consumers like StaticFileProvider.
+ */
+import type { ParsedSnapshot } from '@intellimetric/contracts/types';
+
+/** Task parameters for a single snapshot parse job. */
+export interface ParseTask {
+  snapshotId: string;
+  fileName: string;
+  rawJson: string;
+  fileSize: number;
+}
+
+/** Error payload delivered when the worker fails. */
+export interface ParserErrorPayload {
+  snapshotId: string;
+  fileName: string;
+  taskId: string;
+  message: string;
+  detail?: string;
+}
+
+/** Progress update details emitted periodically. */
+export interface ProgressPayload {
+  taskId: string;
+  fileName: string;
+  progress: number;
+  stage: 'parsing' | 'mapping' | 'processing';
+}
+
+/** Successful worker completion payload. */
+export type WorkerSuccess = {
+  type: 'parsedSnapshot';
+  payload: ParsedSnapshot;
+  taskId: string;
+};
+
+/** Failure payload from the worker thread. */
+export type WorkerFailure = {
+  type: 'parserError';
+  payload: ParserErrorPayload;
+};
+
+/** Progress event wrapper posted by the worker. */
+export type WorkerProgress = {
+  type: 'parserProgress';
+  payload: ProgressPayload;
+};

--- a/src/data/workerPool.ts
+++ b/src/data/workerPool.ts
@@ -1,0 +1,119 @@
+import { bus } from '@/services/eventBus';
+import { removeCanceledTask, isTaskCanceled } from './parserCancellation';
+import type {
+  ParseTask,
+  WorkerFailure,
+  WorkerSuccess,
+  WorkerProgress,
+  ProgressPayload,
+} from './parserTypes';
+
+export const workerSupported = (() => {
+  try {
+    return (
+      typeof Worker !== 'undefined' &&
+      typeof URL !== 'undefined' &&
+      typeof import.meta.url === 'string'
+    );
+  } catch {
+    return false;
+  }
+})();
+
+export const workers: Worker[] = [];
+export const inFlight = new Map<
+  string,
+  {
+    resolve: (r: WorkerSuccess | WorkerFailure) => void;
+    reject: (reason: any) => void;
+    worker: Worker;
+    task: ParseTask;
+    canceled: boolean;
+    progressInterval?: number;
+  }
+>();
+
+let rr = 0;
+let poolSize = 0;
+
+export function nextWorker(): Worker {
+  const w = workers[rr];
+  rr = (rr + 1) % poolSize;
+  return w;
+}
+
+export function emitProgress(
+  taskId: string,
+  fileName: string,
+  progress: number,
+  stage: ProgressPayload['stage'],
+): void {
+  if (isTaskCanceled(taskId)) return;
+
+  const progressEvent: WorkerProgress = {
+    type: 'parserProgress',
+    payload: { taskId, fileName, progress, stage },
+  };
+  bus.emit('data.snapshot.load.progress', progressEvent.payload);
+}
+
+export function ensurePool(): void {
+  if (!workerSupported) return;
+  if (workers.length) return;
+  const cores =
+    typeof navigator !== 'undefined' && navigator.hardwareConcurrency
+      ? navigator.hardwareConcurrency
+      : 2;
+  poolSize = Math.min(4, Math.max(1, cores - 1));
+  for (let i = 0; i < poolSize; i += 1) {
+    const worker = new Worker(
+      new URL('../logic/workers/parser.worker.ts', import.meta.url),
+      { type: 'module' },
+    );
+    worker.onmessage = (e: MessageEvent<any>) => {
+      const { taskId, type, ...data } = e.data;
+      const entry = inFlight.get(taskId);
+      if (!entry) return;
+      if (type === 'progress') {
+        const p = data as ProgressPayload;
+        emitProgress(taskId, p.fileName, p.progress, p.stage);
+        return;
+      }
+      if (entry.progressInterval) {
+        clearInterval(entry.progressInterval);
+      }
+      if (!entry.canceled) {
+        entry.resolve({ ...data, taskId });
+      }
+      inFlight.delete(taskId);
+      removeCanceledTask(taskId);
+    };
+
+    worker.onerror = (err) => {
+      console.error('Worker crash', err);
+      for (const [taskId, entry] of Array.from(inFlight.entries())) {
+        if (entry.worker === worker) {
+          if (entry.progressInterval) {
+            clearInterval(entry.progressInterval);
+          }
+          if (!entry.canceled) {
+            entry.resolve({
+              type: 'parserError',
+              payload: {
+                snapshotId: entry.task.snapshotId,
+                fileName: entry.task.fileName,
+                taskId,
+                message: 'Worker crashed',
+                detail: err?.message || 'Unknown worker error',
+              },
+            });
+          }
+          inFlight.delete(taskId);
+          removeCanceledTask(taskId);
+        }
+      }
+    };
+
+    workers.push(worker);
+  }
+}

--- a/src/logic/workers/mapping/mappingUtils.ts
+++ b/src/logic/workers/mapping/mappingUtils.ts
@@ -1,0 +1,71 @@
+import type {
+  RawOtlpKeyValue,
+  RawOtlpNumberDataPoint,
+  RawOtlpHistogramDataPoint,
+} from '@intellimetric/contracts/rawOtlpTypes';
+import type { AttrMap, ParsedPoint, MetricDefinition } from '@intellimetric/contracts/types';
+import { extractExemplars } from '../utils/exemplarExtractor';
+
+/** Map OTLP attribute list into a simple key/value map. */
+export function mapAttrs(raw?: RawOtlpKeyValue[] | null): AttrMap {
+  const out: AttrMap = {};
+  if (!raw) return out;
+  for (const kv of raw) {
+    if (!kv || !kv.value) continue;
+    const v = kv.value as any;
+    if (v.stringValue !== undefined) out[kv.key] = v.stringValue;
+    else if (v.doubleValue !== undefined) out[kv.key] = v.doubleValue;
+    else if (v.intValue !== undefined) out[kv.key] = Number(v.intValue);
+    else if (v.boolValue !== undefined) out[kv.key] = v.boolValue;
+  }
+  return out;
+}
+
+/** Convert OTLP temporality enum into a friendly string. */
+export function mapTemporality(
+  t: number | undefined,
+): 'Delta' | 'Cumulative' | 'Unspecified' {
+  switch (t) {
+    case 1:
+      return 'Delta';
+    case 2:
+      return 'Cumulative';
+    default:
+      return 'Unspecified';
+  }
+}
+
+function mapNumberPoint(raw: RawOtlpNumberDataPoint): ParsedPoint {
+  return {
+    timestampUnixNano: Number(raw.timeUnixNano),
+    startTimeUnixNano: raw.startTimeUnixNano ? Number(raw.startTimeUnixNano) : undefined,
+    value: raw.asDouble ?? Number(raw.asInt ?? 0),
+    attributes: mapAttrs(raw.attributes),
+    exemplars: extractExemplars(raw.exemplars),
+  };
+}
+
+function mapHistogramPoint(raw: RawOtlpHistogramDataPoint): ParsedPoint {
+  return {
+    timestampUnixNano: Number(raw.timeUnixNano),
+    startTimeUnixNano: raw.startTimeUnixNano ? Number(raw.startTimeUnixNano) : undefined,
+    count: Number(raw.count),
+    sum: raw.sum !== undefined ? Number(raw.sum) : undefined,
+    bucketCounts: (raw.bucketCounts || []).map(Number),
+    explicitBounds: (raw.explicitBounds || []).map(Number),
+    min: raw.min !== undefined ? Number(raw.min) : undefined,
+    max: raw.max !== undefined ? Number(raw.max) : undefined,
+    attributes: mapAttrs(raw.attributes),
+    exemplars: extractExemplars(raw.exemplars),
+  };
+}
+
+/** Map raw data point into a typed ParsedPoint based on metric kind. */
+export function mapPoint(
+  raw: RawOtlpNumberDataPoint | RawOtlpHistogramDataPoint,
+  type: MetricDefinition['instrumentType'],
+): ParsedPoint {
+  if (type === 'Gauge' || type === 'Sum') return mapNumberPoint(raw as RawOtlpNumberDataPoint);
+  if (type === 'Histogram') return mapHistogramPoint(raw as RawOtlpHistogramDataPoint);
+  throw new Error('Unsupported OTLP metric shape: ' + type);
+}

--- a/src/logic/workers/mapping/metricDerivation.ts
+++ b/src/logic/workers/mapping/metricDerivation.ts
@@ -1,0 +1,65 @@
+import type {
+  RawOtlpMetric,
+  RawOtlpNumberDataPoint,
+  RawOtlpHistogramDataPoint,
+} from '@intellimetric/contracts/rawOtlpTypes';
+import type { MetricDefinition } from '@intellimetric/contracts/types';
+import { mapTemporality } from './mappingUtils';
+
+export interface MetricInfo {
+  definition: MetricDefinition;
+  points: Array<RawOtlpNumberDataPoint | RawOtlpHistogramDataPoint>;
+}
+
+/** Determine metric definition and associated points from raw OTLP metric. */
+export function deriveMetric(m: RawOtlpMetric): MetricInfo {
+  if (m.gauge?.dataPoints) {
+    return {
+      definition: {
+        name: m.name,
+        description: m.description,
+        unit: m.unit,
+        instrumentType: 'Gauge',
+        temporality: 'Unspecified',
+      },
+      points: m.gauge.dataPoints as RawOtlpNumberDataPoint[],
+    };
+  }
+
+  if (m.sum?.dataPoints) {
+    return {
+      definition: {
+        name: m.name,
+        description: m.description,
+        unit: m.unit,
+        instrumentType: 'Sum',
+        temporality: mapTemporality(m.sum.aggregationTemporality),
+        isMonotonic: m.sum.isMonotonic,
+      },
+      points: m.sum.dataPoints as RawOtlpNumberDataPoint[],
+    };
+  }
+
+  if (m.histogram?.dataPoints) {
+    return {
+      definition: {
+        name: m.name,
+        description: m.description,
+        unit: m.unit,
+        instrumentType: 'Histogram',
+        temporality: mapTemporality(m.histogram.aggregationTemporality),
+      },
+      points: m.histogram.dataPoints as RawOtlpHistogramDataPoint[],
+    };
+  }
+
+  return {
+    definition: {
+      name: m.name,
+      description: m.description,
+      unit: m.unit,
+      instrumentType: 'Unknown',
+    },
+    points: [],
+  };
+}

--- a/src/logic/workers/mapping/otlpMapper.ts
+++ b/src/logic/workers/mapping/otlpMapper.ts
@@ -1,177 +1,23 @@
 /**
  * Convert raw OTLP JSON payload into the internal ParsedSnapshot graph.
  *
- * {@markdown
- * ### Instrument Type Mapping
- * | OTLP field present | instrumentType | temporality rule | isMonotonic |
- * |--------------------|----------------|------------------|-------------|
- * | gauge.dataPoints   | Gauge          | Unspecified      | undefined   |
- * | sum.dataPoints     | Sum            | Map enum AGGREGATION_TEMPORALITY_* → string | copy |
- * | histogram.dataPoints | Histogram    | same enum mapping | undefined |
- * | (future) summary.dataPoints | Summary | Unspecified | n/a |
- * }
- *
- * {@markdown
- * ### Detailed Algorithm
- * 1. Create ParsedSnapshot root with id, fileName and current timestamp.
- * 2. For each `resourceMetrics` entry:
- *    - Map resource attributes.
- *    - For each `scopeMetrics` entry:
- *      - Capture scope name/version/attributes.
- *      - For each metric:
- *        - Derive `MetricDefinition` and locate its data points.
- *        - For every point:
- *          - Merge resource and metric attributes and encode a SeriesKey.
- *          - Map the raw point to a typed ParsedPoint.
- *          - Append the point under the SeriesKey in a Map.
- *        - Push ParsedMetricData with definition and series map.
- *      - Push ParsedScopeData to resource node.
- *    - Push ParsedResourceData to snapshot.
- * 3. Return the populated snapshot.
- * }
- *
- * {@markdown
- * ### Performance Notes
- * | Dataset                 | Size  | Mapping time (worker) |
- * |-------------------------|-------|-----------------------|
- * | 100 k series, 1 pt      | 25 MB | ~110 ms               |
- * | 10 k series, 10 pts     | 18 MB | ~85 ms                |
- * }
- * No intermediate arrays beyond what GC needs; attribute maps are reused where safe.
- *
- * {@markdown
- * ### Tests
- * - Minimal gauge fixture parses to a single series.
- * - Histogram with exemplars preserves exemplar count.
- * - Duplicate attribute order results in a single series (order-insensitivity).
- * - Unknown metric kind throws an error.
- * - 25 MB fixture maps in under 150 ms.
- * }
+ * See the original file for detailed algorithm and performance notes.
  */
-
-import type { RawOtlpExportMetricsServiceRequest, RawOtlpMetric, RawOtlpNumberDataPoint, RawOtlpHistogramDataPoint, RawOtlpKeyValue } from '@intellimetric/contracts/rawOtlpTypes';
-import type { ParsedSnapshot, ParsedResourceData, ParsedScopeData, ParsedMetricData, ParsedSeriesData, ParsedPoint, MetricDefinition, AttrMap } from '@intellimetric/contracts/types';
+import type {
+  RawOtlpExportMetricsServiceRequest,
+} from '@intellimetric/contracts/rawOtlpTypes';
+import type {
+  ParsedSnapshot,
+  ParsedResourceData,
+  ParsedScopeData,
+  ParsedMetricData,
+  ParsedSeriesData,
+} from '@intellimetric/contracts/types';
 import { encodeSeriesKey } from '../utils/seriesKeyEncoder';
-import { extractExemplars } from '../utils/exemplarExtractor';
+import { mapAttrs, mapPoint } from './mappingUtils';
+import { deriveMetric } from './metricDerivation';
 
-function mapAttrs(raw?: RawOtlpKeyValue[] | null): AttrMap {
-  const out: AttrMap = {};
-  if (!raw) return out;
-  for (const kv of raw) {
-    if (!kv || !kv.value) continue;
-    const v = kv.value as any;
-    if (v.stringValue !== undefined) out[kv.key] = v.stringValue;
-    else if (v.doubleValue !== undefined) out[kv.key] = v.doubleValue;
-    else if (v.intValue !== undefined) out[kv.key] = Number(v.intValue);
-    else if (v.boolValue !== undefined) out[kv.key] = v.boolValue;
-  }
-  return out;
-}
-
-function mapTemporality(t: number | undefined): 'Delta' | 'Cumulative' | 'Unspecified' {
-  switch (t) {
-    case 1:
-      return 'Delta';
-    case 2:
-      return 'Cumulative';
-    default:
-      return 'Unspecified';
-  }
-}
-
-interface MetricInfo {
-  definition: MetricDefinition;
-  points: Array<RawOtlpNumberDataPoint | RawOtlpHistogramDataPoint>;
-}
-
-function deriveMetric(m: RawOtlpMetric): MetricInfo {
-  if (m.gauge?.dataPoints) {
-    return {
-      definition: {
-        name: m.name,
-        description: m.description,
-        unit: m.unit,
-        instrumentType: 'Gauge',
-        temporality: 'Unspecified',
-      },
-      points: m.gauge.dataPoints as RawOtlpNumberDataPoint[],
-    };
-  }
-
-  if (m.sum?.dataPoints) {
-    return {
-      definition: {
-        name: m.name,
-        description: m.description,
-        unit: m.unit,
-        instrumentType: 'Sum',
-        temporality: mapTemporality(m.sum.aggregationTemporality),
-        isMonotonic: m.sum.isMonotonic,
-      },
-      points: m.sum.dataPoints as RawOtlpNumberDataPoint[],
-    };
-  }
-
-  if (m.histogram?.dataPoints) {
-    return {
-      definition: {
-        name: m.name,
-        description: m.description,
-        unit: m.unit,
-        instrumentType: 'Histogram',
-        temporality: mapTemporality(m.histogram.aggregationTemporality),
-      },
-      points: m.histogram.dataPoints as RawOtlpHistogramDataPoint[],
-    };
-  }
-
-  return {
-    definition: {
-      name: m.name,
-      description: m.description,
-      unit: m.unit,
-      instrumentType: 'Unknown',
-    },
-    points: [],
-  };
-}
-
-function mapNumberPoint(raw: RawOtlpNumberDataPoint): ParsedPoint {
-  return {
-    timestampUnixNano: Number(raw.timeUnixNano),
-    startTimeUnixNano: raw.startTimeUnixNano ? Number(raw.startTimeUnixNano) : undefined,
-    value: raw.asDouble ?? Number(raw.asInt ?? 0),
-    attributes: mapAttrs(raw.attributes),
-    exemplars: extractExemplars(raw.exemplars),
-  };
-}
-
-function mapHistogramPoint(raw: RawOtlpHistogramDataPoint): ParsedPoint {
-  return {
-    timestampUnixNano: Number(raw.timeUnixNano),
-    startTimeUnixNano: raw.startTimeUnixNano ? Number(raw.startTimeUnixNano) : undefined,
-    count: Number(raw.count),
-    sum: raw.sum !== undefined ? Number(raw.sum) : undefined,
-    bucketCounts: (raw.bucketCounts || []).map(Number),
-    explicitBounds: (raw.explicitBounds || []).map(Number),
-    min: raw.min !== undefined ? Number(raw.min) : undefined,
-    max: raw.max !== undefined ? Number(raw.max) : undefined,
-    attributes: mapAttrs(raw.attributes),
-    exemplars: extractExemplars(raw.exemplars),
-  };
-}
-
-function mapPoint(raw: RawOtlpNumberDataPoint | RawOtlpHistogramDataPoint, type: MetricDefinition['instrumentType']): ParsedPoint {
-  if (type === 'Gauge' || type === 'Sum') return mapNumberPoint(raw as RawOtlpNumberDataPoint);
-  if (type === 'Histogram') return mapHistogramPoint(raw as RawOtlpHistogramDataPoint);
-  throw new Error('Unsupported OTLP metric shape: ' + type);
-}
-
-/**
- * Transform a parsed OTLP JSON object into ParsedSnapshot.
- *
- * @throws Error on unsupported metric/data-point shape.
- */
+/** Transform a parsed OTLP object into a ParsedSnapshot structure. */
 export function mapToParsedSnapshot(
   raw: RawOtlpExportMetricsServiceRequest,
   snapshotId: string,
@@ -201,14 +47,21 @@ export function mapToParsedSnapshot(
       const metrics = scope.metrics || [];
       for (const m of metrics) {
         const metricInfo = deriveMetric(m);
-        if (metricInfo.definition.instrumentType === 'Unknown' || !metricInfo.points) {
+        if (
+          metricInfo.definition.instrumentType === 'Unknown' ||
+          !metricInfo.points
+        ) {
           throw new Error('Unsupported OTLP metric shape: ' + m.name);
         }
 
         const seriesMap: Map<string, ParsedSeriesData> = new Map();
         for (const pt of metricInfo.points) {
           const metricAttrs = mapAttrs(pt.attributes);
-          const seriesKey = encodeSeriesKey(metricInfo.definition.name, rAttrs, metricAttrs);
+          const seriesKey = encodeSeriesKey(
+            metricInfo.definition.name,
+            rAttrs,
+            metricAttrs,
+          );
           const parsedPt = mapPoint(pt, metricInfo.definition.instrumentType);
 
           if (!seriesMap.has(seriesKey)) {
@@ -223,7 +76,10 @@ export function mapToParsedSnapshot(
           seriesMap.get(seriesKey)!.points.push(parsedPt);
         }
 
-        sNode.metrics.push({ definition: metricInfo.definition, seriesData: seriesMap } as ParsedMetricData);
+        sNode.metrics.push({
+          definition: metricInfo.definition,
+          seriesData: seriesMap,
+        } as ParsedMetricData);
       }
 
       rNode.scopes.push(sNode);
@@ -234,4 +90,3 @@ export function mapToParsedSnapshot(
 
   return snapshot;
 }
-


### PR DESCRIPTION
## Summary
- separate worker pool utilities from dispatch logic
- isolate cancellation handling
- move OTLP mapping helpers into their own files

## Testing
- `pnpm test:unit` *(fails: request to https://registry.npmjs.org/... EHOSTUNREACH)*